### PR TITLE
Add from_graph for AdjacenyList

### DIFF
--- a/src/adjacency_list/map_adjacency_list.rs
+++ b/src/adjacency_list/map_adjacency_list.rs
@@ -313,12 +313,9 @@ mod tests {
         );
     }
 
-    fn test_nodes_iterable<NI, T: NodesIterable<Node = NI>>(iter: T) {}
-
-    fn test_nodes_iterable_with_ni<NI, T: NodesIterable<Node = NI>>(iter: T, ni: NI) {}
 
     #[test]
-    fn test_map_adjaceny_list_not_all_edges() {
+    fn test_map_adjacency_list_not_all_edges() {
         let mut dict = Dictionary::<_, NodeStructOption<3, _>, 5>::new();
         dict.insert(0, NodeStructOption([Some(1), Some(2), None]))
             .unwrap();

--- a/src/adjacency_list/map_adjacency_list.rs
+++ b/src/adjacency_list/map_adjacency_list.rs
@@ -313,7 +313,6 @@ mod tests {
         );
     }
 
-
     #[test]
     fn test_map_adjacency_list_not_all_edges() {
         let mut dict = Dictionary::<_, NodeStructOption<3, _>, 5>::new();

--- a/src/adjacency_list/map_adjacency_list.rs
+++ b/src/adjacency_list/map_adjacency_list.rs
@@ -1,6 +1,6 @@
 use crate::containers::maps::MapTrait;
 use crate::graph::{integrity_check, Graph, GraphError, NodeIndex};
-use crate::nodes::NodesIterable;
+use crate::nodes::{AddNode, NodesIterable};
 
 use super::outgoing_nodes::AsOutgoingNodes;
 
@@ -44,6 +44,34 @@ where
     }
 }
 
+impl<NI, E, C, M> MapAdjacencyList<NI, E, C, M>
+where
+    NI: NodeIndex,
+    E: NodesIterable<Node = NI>,
+    C: AsOutgoingNodes<NI, E> + AddNode<NI> + Default,
+    M: MapTrait<NI, C>,
+{
+    pub fn from_graph<G: Graph<NI>>(source_graph: &G) -> Result<Self, G::Error>
+    where
+        G::Error: core::fmt::Debug,
+    {
+        let mut nodes = M::new();
+        for node in source_graph.iter_nodes()? {
+            let mut outbound = C::default();
+            for edge in source_graph.outgoing_edges(node)? {
+                outbound.add(edge);
+            }
+            nodes
+                .insert(node, outbound)
+                .map_err(|_| GraphError::OutOfCapacity)?;
+        }
+        Ok(Self {
+            nodes,
+            _phantom: Default::default(),
+        })
+    }
+}
+
 impl<NI, E, C, M> Graph<NI> for MapAdjacencyList<NI, E, C, M>
 where
     M: MapTrait<NI, C>,
@@ -81,7 +109,9 @@ where
 mod tests {
     use super::*;
     use crate::containers::maps::staticdict::Dictionary;
-    use crate::tests::collect;
+    use crate::edgelist::edge_list::EdgeList;
+    use crate::nodes::NodeStructOption;
+    use crate::tests::{collect, collect_sorted};
 
     #[test]
     fn test_map_adjacency_list_new() {
@@ -93,8 +123,7 @@ mod tests {
         let graph = MapAdjacencyList::new(dict).unwrap();
 
         let mut nodes = [0usize; 4];
-        let nodes_slice = collect(graph.iter_nodes().unwrap(), &mut nodes);
-        nodes_slice.sort_unstable();
+        let nodes_slice = collect_sorted(graph.iter_nodes().unwrap(), &mut nodes);
         assert_eq!(nodes_slice, &[0, 1, 2]);
     }
 
@@ -108,8 +137,7 @@ mod tests {
         let graph = MapAdjacencyList::new_unchecked(dict);
 
         let mut nodes = [0usize; 4];
-        let nodes_slice = collect(graph.iter_nodes().unwrap(), &mut nodes);
-        nodes_slice.sort_unstable();
+        let nodes_slice = collect_sorted(graph.iter_nodes().unwrap(), &mut nodes);
         assert_eq!(nodes_slice, &[0, 1, 2]);
     }
 
@@ -258,8 +286,7 @@ mod tests {
 
         // Test self-loop edges
         let mut edges = [(0usize, 0usize); 8];
-        let edges_slice = collect(graph.iter_edges().unwrap(), &mut edges);
-        edges_slice.sort_unstable();
+        let edges_slice = collect_sorted(graph.iter_edges().unwrap(), &mut edges);
         assert_eq!(edges_slice, &[(0, 0), (0, 1), (1, 1), (1, 1)]);
 
         // Test outgoing edges with self-loops
@@ -279,11 +306,65 @@ mod tests {
 
         // Test multiple edges pointing to same target
         let mut edges = [(0usize, 0usize); 8];
-        let edges_slice = collect(graph.iter_edges().unwrap(), &mut edges);
-        edges_slice.sort_unstable();
+        let edges_slice = collect_sorted(graph.iter_edges().unwrap(), &mut edges);
         assert_eq!(
             edges_slice,
             &[(0, 1), (0, 1), (1, 0), (1, 0), (2, 0), (2, 1)]
+        );
+    }
+
+    fn test_nodes_iterable<NI, T: NodesIterable<Node = NI>>(iter: T) {}
+
+    fn test_nodes_iterable_with_ni<NI, T: NodesIterable<Node = NI>>(iter: T, ni: NI) {}
+
+    #[test]
+    fn test_map_adjaceny_list_not_all_edges() {
+        let mut dict = Dictionary::<_, NodeStructOption<3, _>, 5>::new();
+        dict.insert(0, NodeStructOption([Some(1), Some(2), None]))
+            .unwrap();
+        dict.insert(1, NodeStructOption([Some(2), Some(0), None]))
+            .unwrap();
+        dict.insert(2, NodeStructOption([Some(0), None, None]))
+            .unwrap();
+
+        let graph = MapAdjacencyList::new_unchecked(dict);
+        let mut edges = [(0usize, 0usize); 8];
+        let edges_slice = collect(graph.iter_edges().unwrap(), &mut edges);
+        assert_eq!(edges_slice, &[(2, 0), (0, 1), (0, 2), (1, 2), (1, 0)]);
+    }
+
+    #[test]
+    fn test_map_adjacency_list_from_graph() {
+        let src_graph = EdgeList::<8, _, _>::new([(0, 1), (0, 2), (1, 3), (2, 3)]);
+        let adjlist =
+            MapAdjacencyList::<_, _, _, Dictionary<_, NodeStructOption<5, _>, 5>>::from_graph(
+                &src_graph,
+            )
+            .unwrap();
+
+        let mut nodes = [0usize; 8];
+        let node_slice = collect_sorted(adjlist.iter_nodes().unwrap(), &mut nodes);
+        assert_eq!(node_slice, &[0usize, 1, 2, 3]);
+
+        let mut edges = [(0usize, 0usize); 8];
+        let edge_slice = collect_sorted(adjlist.iter_edges().unwrap(), &mut edges);
+        assert_eq!(edge_slice, &[(0, 1), (0, 2), (1, 3), (2, 3)]);
+
+        assert_eq!(
+            collect_sorted(adjlist.outgoing_edges(0).unwrap(), &mut nodes),
+            &[1, 2]
+        );
+        assert_eq!(
+            collect_sorted(adjlist.outgoing_edges(1).unwrap(), &mut nodes),
+            &[3]
+        );
+        assert_eq!(
+            collect_sorted(adjlist.outgoing_edges(2).unwrap(), &mut nodes),
+            &[3]
+        );
+        assert_eq!(
+            collect_sorted(adjlist.outgoing_edges(3).unwrap(), &mut nodes),
+            &[]
         );
     }
 }

--- a/src/containers/maps/staticdict.rs
+++ b/src/containers/maps/staticdict.rs
@@ -209,7 +209,7 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::tests::{collect, collect_sorted};
+    use crate::tests::collect_sorted;
 
     #[test]
     fn test_iter_with_gaps() {

--- a/src/containers/maps/staticdict.rs
+++ b/src/containers/maps/staticdict.rs
@@ -209,7 +209,7 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::tests::collect;
+    use crate::tests::{collect, collect_sorted};
 
     #[test]
     fn test_iter_with_gaps() {
@@ -219,8 +219,7 @@ mod test {
         dict.insert(3, 'c').unwrap();
 
         let mut values = ['\0'; 5];
-        let values_slice = collect(dict.iter().map(|(_, v)| *v), &mut values);
-        values_slice.sort_unstable();
+        let values_slice = collect_sorted(dict.iter().map(|(_, v)| *v), &mut values);
         assert_eq!(values_slice, &['a', 'b', 'c']);
     }
 

--- a/src/edgelist/edge_list.rs
+++ b/src/edgelist/edge_list.rs
@@ -87,7 +87,7 @@ mod tests {
     use super::*;
     use crate::edges::EdgeNodeError;
     use crate::graph::{GraphError, GraphWithEdgeValues};
-    use crate::tests::collect;
+    use crate::tests::{collect, collect_sorted};
 
     #[test]
     fn test_edge_list_new() {
@@ -214,8 +214,7 @@ mod tests {
         // Test node iteration (this uses EdgesToNodesIterator internally)
         let nodes_iter = edge_list.iter_nodes().unwrap();
         let mut nodes = [0usize; 10];
-        let nodes_slice = collect(nodes_iter, &mut nodes);
-        nodes_slice.sort_unstable();
+        let nodes_slice = collect_sorted(nodes_iter, &mut nodes);
         assert_eq!(nodes_slice, &[0, 1, 2]);
     }
 

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -30,6 +30,8 @@ pub enum GraphError<NI: NodeIndex> {
     IndexOutOfBounds(usize, NI),
     /// Matrix size is invalid
     InvalidMatrixSize,
+    // Out of capacity for adding nodes
+    OutOfCapacity,
     /// Unexpected condition occurred
     Unexpected,
 }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -30,7 +30,7 @@ pub enum GraphError<NI: NodeIndex> {
     IndexOutOfBounds(usize, NI),
     /// Matrix size is invalid
     InvalidMatrixSize,
-    // Out of capacity for adding nodes
+    /// Out of capacity for adding nodes
     OutOfCapacity,
     /// Unexpected condition occurred
     Unexpected,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,11 +86,21 @@ pub use visited::VisitedTracker;
 
 #[cfg(test)]
 mod tests {
+    /// Collects elements from an iterator into a slice, returning the slice.
     pub(crate) fn collect<T: Copy, I: Iterator<Item = T>>(iter: I, dest: &mut [T]) -> &mut [T] {
         let slice_len = iter
             .zip(dest.iter_mut())
             .map(|(item, slot)| *slot = item)
             .count();
         &mut dest[..slice_len]
+    }
+    /// Collects elements from an iterator into a sorted slice, returning the slice.
+    pub(crate) fn collect_sorted<T: Copy + Ord, I: Iterator<Item = T>>(
+        iter: I,
+        dest: &mut [T],
+    ) -> &mut [T] {
+        let slice = collect(iter, dest);
+        slice.sort_unstable();
+        slice
     }
 }

--- a/src/matrix/bit_matrix.rs
+++ b/src/matrix/bit_matrix.rs
@@ -127,7 +127,7 @@ impl<const C: usize, const R: usize> Graph<usize> for BitMatrix<C, R> {
 mod tests {
 
     use super::*;
-    use crate::tests::collect;
+    use crate::tests::{collect, collect_sorted};
 
     #[test]
     fn test_bit_matrix_basic() {
@@ -415,8 +415,7 @@ mod tests {
 
         // Test node 1's incoming edges (should be from nodes 0 and 3)
         let mut edges = [0usize; 4];
-        let edges_slice = collect(matrix.incoming_edges(1).unwrap(), &mut edges);
-        edges_slice.sort_unstable();
+        let edges_slice = collect_sorted(matrix.incoming_edges(1).unwrap(), &mut edges);
         assert_eq!(edges_slice, &[0, 3]);
 
         // Test node 2's incoming edges (should be from node 1)
@@ -500,8 +499,7 @@ mod tests {
 
         // Test node 1's incoming edges
         let mut edges = [0usize; 4];
-        let edges_slice = collect(matrix.incoming_edges(1).unwrap(), &mut edges);
-        edges_slice.sort_unstable();
+        let edges_slice = collect_sorted(matrix.incoming_edges(1).unwrap(), &mut edges);
         assert_eq!(edges_slice, &[0, 2, 3]);
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a method to construct adjacency lists from existing graphs, with error handling for capacity limits.
  - Introduced a new error type indicating when a graph exceeds its capacity.

- **Tests**
  - Simplified and improved test clarity by introducing and using a helper to collect and sort iterator results.
  - Added and updated tests to verify the new adjacency list construction and edge iteration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->