### PR TITLE
From_graph impls

### DIFF
--- a/examples/from_graph_demo.rs
+++ b/examples/from_graph_demo.rs
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Graph conversion demonstration
+//!
+//! This example demonstrates how to convert between different graph types
+//! using the `from_graph` functionality.
+
+use heapless_graphs::{
+    adjacency_list::map_adjacency_list::MapAdjacencyList,
+    containers::maps::{staticdict::Dictionary, MapTrait},
+    edgelist::edge_list::EdgeList,
+    edges::EdgeStructOption,
+    graph::Graph,
+};
+
+fn main() {
+    println!("Graph Conversion Demo");
+    println!("====================");
+
+    // Example 1: Convert MapAdjacencyList to EdgeList
+    println!("\n1. Converting Adjacency List to Edge List");
+
+    // Create a MapAdjacencyList representing a small social network
+    // 0 (Alice) -> [1 (Bob), 2 (Charlie)]
+    // 1 (Bob) -> [2 (Charlie), 3 (David)]
+    // 2 (Charlie) -> [3 (David)]
+    let mut dict = Dictionary::<usize, [usize; 2], 8>::new();
+    dict.insert(0, [1, 2]).unwrap(); // Alice knows Bob and Charlie
+    dict.insert(1, [2, 3]).unwrap(); // Bob knows Charlie and David
+    dict.insert(2, [3, 0]).unwrap(); // Charlie knows David and Alice (back-reference)
+    dict.insert(3, [0, 1]).unwrap(); // David knows Alice and Bob
+
+    let adjacency_graph = MapAdjacencyList::new_unchecked(dict);
+
+    println!("Original adjacency list graph:");
+    print_graph_info(&adjacency_graph);
+
+    // Convert to EdgeList
+    let edge_list_graph: EdgeList<8, usize, EdgeStructOption<16, usize>> =
+        EdgeList::from_graph(&adjacency_graph).unwrap();
+
+    println!("\nConverted to edge list:");
+    print_graph_info(&edge_list_graph);
+
+    // Example 2: Working with the converted graph
+    println!("\n2. Working with the Converted Graph");
+
+    // Both graphs should have the same edges and nodes
+    let mut adj_edges = [(0usize, 0usize); 16];
+    let mut edge_edges = [(0usize, 0usize); 16];
+
+    let adj_edge_slice = collect(adjacency_graph.iter_edges().unwrap(), &mut adj_edges);
+    let edge_edge_slice = collect(edge_list_graph.iter_edges().unwrap(), &mut edge_edges);
+
+    println!("Edge count comparison:");
+    println!("  Adjacency list: {} edges", adj_edge_slice.len());
+    println!("  Edge list: {} edges", edge_edge_slice.len());
+    assert_eq!(adj_edge_slice.len(), edge_edge_slice.len());
+
+    let mut adj_nodes = [0usize; 8];
+    let mut edge_nodes = [0usize; 8];
+
+    let adj_node_slice = collect(adjacency_graph.iter_nodes().unwrap(), &mut adj_nodes);
+    let edge_node_slice = collect(edge_list_graph.iter_nodes().unwrap(), &mut edge_nodes);
+
+    println!("Node count comparison:");
+    println!("  Adjacency list: {} nodes", adj_node_slice.len());
+    println!("  Edge list: {} nodes", edge_node_slice.len());
+    assert_eq!(adj_node_slice.len(), edge_node_slice.len());
+
+    // Example 3: Converting a simple chain graph
+    println!("\n3. Converting a Chain Graph");
+
+    let mut chain_dict = Dictionary::<usize, [usize; 1], 8>::new();
+    chain_dict.insert(0, [1]).unwrap(); // 0 -> 1
+    chain_dict.insert(1, [2]).unwrap(); // 1 -> 2
+    chain_dict.insert(2, [3]).unwrap(); // 2 -> 3
+    chain_dict.insert(3, [4]).unwrap(); // 3 -> 4
+
+    let chain_adjacency = MapAdjacencyList::new_unchecked(chain_dict);
+
+    println!("Chain graph (adjacency list):");
+    print_graph_info(&chain_adjacency);
+
+    let chain_edge_list: EdgeList<8, usize, EdgeStructOption<8, usize>> =
+        EdgeList::from_graph(&chain_adjacency).unwrap();
+
+    println!("Chain graph (edge list):");
+    print_graph_info(&chain_edge_list);
+
+    // Example 4: Converting an empty graph
+    println!("\n4. Converting an Empty Graph");
+
+    let empty_dict = Dictionary::<usize, [usize; 2], 8>::new();
+    let empty_adjacency = MapAdjacencyList::new_unchecked(empty_dict);
+
+    let empty_edge_list: EdgeList<8, usize, EdgeStructOption<8, usize>> =
+        EdgeList::from_graph(&empty_adjacency).unwrap();
+
+    println!("Empty graph conversions:");
+    println!(
+        "  Adjacency list - nodes: {}, edges: {}",
+        empty_adjacency.iter_nodes().unwrap().count(),
+        empty_adjacency.iter_edges().unwrap().count()
+    );
+
+    // EdgeList may fail on iter_nodes for empty graphs, so handle gracefully
+    let edge_list_node_count = match empty_edge_list.iter_nodes() {
+        Ok(iter) => iter.count(),
+        Err(_) => 0, // Empty edge list has no nodes
+    };
+    println!(
+        "  Edge list - nodes: {}, edges: {}",
+        edge_list_node_count,
+        empty_edge_list.iter_edges().unwrap().count()
+    );
+
+    println!("\nGraph conversion is useful for:");
+    println!("- Converting between different graph representations");
+    println!("- Optimizing for different use cases (space vs. query speed)");
+    println!("- Interfacing between different parts of an application");
+    println!("- Testing graph algorithms with different backing stores");
+}
+
+/// Helper function to print basic graph information
+fn print_graph_info<G: Graph<usize>>(graph: &G)
+where
+    G::Error: core::fmt::Debug,
+{
+    let node_count = graph.iter_nodes().unwrap().count();
+    let edge_count = graph.iter_edges().unwrap().count();
+
+    println!("  Nodes: {}, Edges: {}", node_count, edge_count);
+
+    if edge_count <= 8 {
+        // Only print edges for small graphs
+        print!("  Edges: ");
+        for (i, (from, to)) in graph.iter_edges().unwrap().enumerate() {
+            if i > 0 {
+                print!(", ");
+            }
+            print!("{}→{}", from, to);
+        }
+        println!();
+    }
+}
+
+/// Helper function to collect iterator into slice (copied from tests)
+fn collect<T: Copy, I: Iterator<Item = T>>(iter: I, dest: &mut [T]) -> &mut [T] {
+    let slice_len = iter
+        .zip(dest.iter_mut())
+        .map(|(item, slot)| *slot = item)
+        .count();
+    &mut dest[..slice_len]
+}

--- a/src/adjacency_list/map_adjacency_list.rs
+++ b/src/adjacency_list/map_adjacency_list.rs
@@ -212,6 +212,7 @@ mod tests {
     use super::*;
     use crate::containers::maps::staticdict::Dictionary;
     use crate::edgelist::edge_list::EdgeList;
+    use crate::graph::GraphWithMutableEdges;
     use crate::nodes::NodeStructOption;
     use crate::tests::{collect, collect_sorted};
 
@@ -569,8 +570,6 @@ mod tests {
 
     #[test]
     fn test_add_edge_success() {
-        use crate::graph::GraphWithMutableEdges;
-
         let mut dict = Dictionary::<usize, NodeStructOption<3, usize>, 5>::new();
         dict.insert(0, NodeStructOption([None, None, None]))
             .unwrap(); // Empty adjacency list
@@ -598,8 +597,6 @@ mod tests {
 
     #[test]
     fn test_add_edge_invalid_nodes() {
-        use crate::graph::GraphWithMutableEdges;
-
         let mut dict = Dictionary::<usize, NodeStructOption<2, usize>, 5>::new();
         dict.insert(0, NodeStructOption([None, None])).unwrap();
         dict.insert(1, NodeStructOption([None, None])).unwrap(); // Only nodes 0, 1
@@ -621,8 +618,6 @@ mod tests {
 
     #[test]
     fn test_add_edge_capacity_exceeded() {
-        use crate::graph::GraphWithMutableEdges;
-
         let mut dict = Dictionary::<usize, NodeStructOption<2, usize>, 5>::new();
         dict.insert(0, NodeStructOption([None, None])).unwrap(); // Capacity for only 2 edges
         dict.insert(1, NodeStructOption([None, None])).unwrap();
@@ -641,8 +636,6 @@ mod tests {
 
     #[test]
     fn test_remove_edge_success() {
-        use crate::graph::GraphWithMutableEdges;
-
         let mut dict = Dictionary::<usize, NodeStructOption<3, usize>, 5>::new();
         dict.insert(0, NodeStructOption([Some(1), Some(2), None]))
             .unwrap();
@@ -668,8 +661,6 @@ mod tests {
 
     #[test]
     fn test_remove_edge_not_found() {
-        use crate::graph::GraphWithMutableEdges;
-
         let mut dict = Dictionary::<usize, NodeStructOption<2, usize>, 5>::new();
         dict.insert(0, NodeStructOption([Some(1), None])).unwrap();
         dict.insert(1, NodeStructOption([None, None])).unwrap();
@@ -687,8 +678,6 @@ mod tests {
 
     #[test]
     fn test_remove_edge_with_nonexistent_nodes() {
-        use crate::graph::GraphWithMutableEdges;
-
         let mut dict = Dictionary::<usize, NodeStructOption<1, usize>, 5>::new();
         dict.insert(0, NodeStructOption([Some(1)])).unwrap();
         dict.insert(1, NodeStructOption([None])).unwrap(); // Only nodes 0, 1
@@ -705,8 +694,6 @@ mod tests {
 
     #[test]
     fn test_add_remove_edge_comprehensive() {
-        use crate::graph::GraphWithMutableEdges;
-
         let mut dict = Dictionary::<usize, NodeStructOption<5, usize>, 5>::new();
         dict.insert(0, NodeStructOption([None, None, None, None, None]))
             .unwrap();

--- a/src/adjacency_list/map_adjacency_list.rs
+++ b/src/adjacency_list/map_adjacency_list.rs
@@ -48,6 +48,32 @@ where
     E: NodesIterable<Node = NI> + MutableNodes<NI> + Default,
     M: MapTrait<NI, E>,
 {
+    /// Creates a MapAdjacencyList from any graph by copying all nodes and edges
+    ///
+    /// This function creates a mapping from node indices to edge containers and populates
+    /// each node's adjacency list with its outgoing edges.
+    ///
+    /// # Arguments
+    /// * `source_graph` - The graph to copy nodes and edges from
+    ///
+    /// # Returns
+    /// * `Ok(MapAdjacencyList)` if successful
+    /// * `Err(G::Error)` if iteration over the source graph fails
+    ///
+    /// # Example
+    /// # use heapless_graphs::adjacency_list::map_adjacency_list::MapAdjacencyList;
+    /// # use heapless_graphs::edgelist::edge_list::EdgeList;
+    /// # use heapless_graphs::edges::EdgeStructOption;
+    /// # use heapless_graphs::containers::maps::staticdict::Dictionary;
+    /// # use heapless_graphs::nodes::NodeStructOption;
+    ///
+    /// // Create a source graph (edge list)
+    /// let edges = EdgeStructOption([Some((0, 1)), Some((1, 2)), Some((0, 2)), None]);
+    /// let source = EdgeList::<4, usize, _>::new(edges);
+    ///
+    /// // Convert to MapAdjacencyList
+    /// let map_adj_list: MapAdjacencyList<usize, NodeStructOption<4, _>, Dictionary<_, _, 8>> =
+    ///     MapAdjacencyList::from_graph(&source).unwrap();
     pub fn from_graph<G: Graph<NI>>(source_graph: &G) -> Result<Self, G::Error>
     where
         G::Error: core::fmt::Debug,

--- a/src/adjacency_list/slice_adjacency_list.rs
+++ b/src/adjacency_list/slice_adjacency_list.rs
@@ -128,6 +128,84 @@ where
     }
 }
 
+impl<NI, E, const N: usize> SliceAdjacencyList<NI, E, [(NI, E); N]>
+where
+    NI: NodeIndex + Copy + Default,
+    E: NodesIterable<Node = NI> + crate::nodes::MutableNodes<NI> + Default,
+{
+    /// Creates a SliceAdjacencyList from any graph by copying all nodes and edges
+    ///
+    /// This function works with fixed-size arrays and creates exactly N entries,
+    /// one for each node in the source graph. The source graph must have exactly
+    /// N nodes, otherwise the conversion will fail.
+    ///
+    /// # Arguments
+    /// * `source_graph` - The graph to copy nodes and edges from
+    ///
+    /// # Returns
+    /// * `Ok(SliceAdjacencyList)` if successful
+    /// * `Err(GraphError)` if node count doesn't match N or capacity is exceeded
+    ///
+    /// # Constraints
+    /// * Source graph must have exactly N nodes
+    /// * Node index type must implement Copy and Default
+    /// * Edge container E must implement Default and MutableNodes
+    /// * Requires sufficient capacity in E for all outgoing edges per node
+    ///
+    /// # Example
+    /// ```
+    /// use heapless_graphs::adjacency_list::slice_adjacency_list::SliceAdjacencyList;
+    /// use heapless_graphs::adjacency_list::map_adjacency_list::MapAdjacencyList;
+    /// use heapless_graphs::containers::maps::staticdict::Dictionary;
+    /// use heapless_graphs::containers::maps::MapTrait;
+    /// use heapless_graphs::nodes::NodeStructOption;
+    ///
+    /// // Create a source graph (adjacency list)
+    /// let mut dict = Dictionary::<usize, [usize; 2], 8>::new();
+    /// dict.insert(0, [1, 2]).unwrap();
+    /// dict.insert(1, [2, 0]).unwrap();
+    /// dict.insert(2, [0, 1]).unwrap();
+    /// let source = MapAdjacencyList::new_unchecked(dict);
+    ///
+    /// // Convert to SliceAdjacencyList with exactly 3 nodes and capacity for edges
+    /// let slice_graph: SliceAdjacencyList<usize, NodeStructOption<4, usize>, [(usize, NodeStructOption<4, usize>); 3]> =
+    ///     SliceAdjacencyList::from_graph(&source).unwrap();
+    /// ```
+    pub fn from_graph<G>(source_graph: &G) -> Result<Self, GraphError<NI>>
+    where
+        G: Graph<NI>,
+        GraphError<NI>: From<G::Error>,
+    {
+        // Check if we have exactly the right number of nodes
+        let node_count = source_graph.iter_nodes()?.count();
+        if node_count != N {
+            return Err(GraphError::OutOfCapacity);
+        }
+
+        // Create an array with exactly N entries using from_fn to avoid Copy requirement
+        let mut container =
+            core::array::from_fn::<(NI, E), N, _>(|_| (NI::default(), E::default()));
+
+        // Collect nodes and initialize each with an empty edge container
+        for (i, node) in source_graph.iter_nodes()?.enumerate() {
+            container[i] = (node, E::default());
+        }
+
+        // Now populate edges for each node
+        for (node, edge_container) in container.iter_mut().take(N) {
+            // Collect outgoing edges for this node
+            let outgoing_iter = source_graph.outgoing_edges(*node)?;
+            for target in outgoing_iter {
+                if edge_container.add(target).is_none() {
+                    return Err(GraphError::OutOfCapacity);
+                }
+            }
+        }
+
+        Ok(Self::new_unchecked(container))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -527,5 +605,74 @@ mod tests {
         let mut edges = [(0usize, 0usize); 8];
         let edges_slice = collect_sorted(graph.iter_edges().unwrap(), &mut edges);
         assert_eq!(edges_slice, &[(0, 1), (0, 2), (1, 2), (2, 0)]);
+    }
+
+    #[cfg(test)]
+    mod from_graph_tests {
+        use super::*;
+        use crate::tests::collect_sorted;
+
+        #[test]
+        fn test_slice_adjacency_list_from_graph_exact_size() {
+            use crate::adjacency_list::map_adjacency_list::MapAdjacencyList;
+            use crate::containers::maps::staticdict::Dictionary;
+            use crate::containers::maps::MapTrait;
+            use crate::nodes::NodeStructOption;
+
+            // Create a source graph with exactly 3 nodes: 0, 1, 2
+            let mut dict = Dictionary::<usize, [usize; 2], 8>::new();
+            dict.insert(0, [1, 2]).unwrap(); // 0 -> 1, 2
+            dict.insert(1, [2, 0]).unwrap(); // 1 -> 2, 0
+            dict.insert(2, [0, 1]).unwrap(); // 2 -> 0, 1
+            let source = MapAdjacencyList::new_unchecked(dict);
+
+            // Convert to SliceAdjacencyList with exactly 3 nodes
+            let slice_graph: SliceAdjacencyList<
+                usize,
+                NodeStructOption<4, usize>,
+                [(usize, NodeStructOption<4, usize>); 3],
+            > = SliceAdjacencyList::from_graph(&source).unwrap();
+
+            // Verify nodes were copied correctly (exactly 3)
+            let mut nodes = [0usize; 8];
+            let nodes_slice = collect_sorted(slice_graph.iter_nodes().unwrap(), &mut nodes);
+            assert_eq!(nodes_slice, &[0, 1, 2]);
+
+            // Verify edges were copied correctly
+            let mut edges = [(0usize, 0usize); 16];
+            let edges_slice = collect_sorted(slice_graph.iter_edges().unwrap(), &mut edges);
+            assert_eq!(
+                edges_slice,
+                &[(0, 1), (0, 2), (1, 0), (1, 2), (2, 0), (2, 1)]
+            );
+        }
+
+        #[test]
+        fn test_slice_adjacency_list_from_graph_wrong_node_count() {
+            use crate::adjacency_list::map_adjacency_list::MapAdjacencyList;
+            use crate::containers::maps::staticdict::Dictionary;
+            use crate::containers::maps::MapTrait;
+            use crate::nodes::NodeStructOption;
+
+            // Create a source graph with 3 nodes
+            let mut dict = Dictionary::<usize, [usize; 2], 8>::new();
+            dict.insert(0, [1, 2]).unwrap();
+            dict.insert(1, [2, 0]).unwrap();
+            dict.insert(2, [0, 1]).unwrap();
+            let source = MapAdjacencyList::new_unchecked(dict);
+
+            // Try to convert to SliceAdjacencyList with 4 nodes (wrong size)
+            let result: Result<
+                SliceAdjacencyList<
+                    usize,
+                    NodeStructOption<4, usize>,
+                    [(usize, NodeStructOption<4, usize>); 4],
+                >,
+                _,
+            > = SliceAdjacencyList::from_graph(&source);
+
+            // Should fail because source has 3 nodes but target expects exactly 4
+            assert!(matches!(result, Err(GraphError::OutOfCapacity)));
+        }
     }
 }

--- a/src/adjacency_list/slice_adjacency_list.rs
+++ b/src/adjacency_list/slice_adjacency_list.rs
@@ -154,21 +154,16 @@ where
     ///
     /// # Example
     /// ```
-    /// use heapless_graphs::adjacency_list::slice_adjacency_list::SliceAdjacencyList;
-    /// use heapless_graphs::adjacency_list::map_adjacency_list::MapAdjacencyList;
-    /// use heapless_graphs::containers::maps::staticdict::Dictionary;
-    /// use heapless_graphs::containers::maps::MapTrait;
-    /// use heapless_graphs::nodes::NodeStructOption;
+    /// # use heapless_graphs::adjacency_list::slice_adjacency_list::SliceAdjacencyList;
+    /// # use heapless_graphs::edgelist::edge_list::EdgeList;
+    /// # use heapless_graphs::containers::maps::MapTrait;
+    /// # use heapless_graphs::nodes::NodeStructOption;
     ///
-    /// // Create a source graph (adjacency list)
-    /// let mut dict = Dictionary::<usize, [usize; 2], 8>::new();
-    /// dict.insert(0, [1, 2]).unwrap();
-    /// dict.insert(1, [2, 0]).unwrap();
-    /// dict.insert(2, [0, 1]).unwrap();
-    /// let source = MapAdjacencyList::new_unchecked(dict);
+    /// // Create a source graph (edge list)
+    /// let source = EdgeList::<5, _,_>::new([(0, 1), (0, 2), (1, 2), (2, 0)]);
     ///
     /// // Convert to SliceAdjacencyList with exactly 3 nodes and capacity for edges
-    /// let slice_graph: SliceAdjacencyList<usize, NodeStructOption<4, usize>, [(usize, NodeStructOption<4, usize>); 3]> =
+    /// let slice_graph: SliceAdjacencyList<usize, NodeStructOption<4, _>, [(_, _); 3]> =
     ///     SliceAdjacencyList::from_graph(&source).unwrap();
     /// ```
     pub fn from_graph<G>(source_graph: &G) -> Result<Self, GraphError<NI>>

--- a/src/algorithms/traversal.rs
+++ b/src/algorithms/traversal.rs
@@ -196,9 +196,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::adjacency_list::{
-        map_adjacency_list::MapAdjacencyList, slice_adjacency_list::SliceAdjacencyList,
-    };
+    use crate::adjacency_list::map_adjacency_list::MapAdjacencyList;
+    use crate::adjacency_list::slice_adjacency_list::SliceAdjacencyList;
     use crate::containers::{
         maps::{staticdict::Dictionary, MapTrait},
         queues::CircularQueue,
@@ -751,13 +750,6 @@ mod tests {
 
     #[test]
     fn test_bfs_with_map_adjacency_list() {
-        use crate::adjacency_list::map_adjacency_list::MapAdjacencyList;
-        use crate::containers::{
-            maps::{staticdict::Dictionary, MapTrait},
-            queues::CircularQueue,
-        };
-        use crate::nodes::NodeStruct;
-
         // Create a map adjacency list - this will benefit from O(1) contains_node
         let mut map = Dictionary::<usize, NodeStruct<3, usize>, 8>::new();
         map.insert(0, NodeStruct([1, 2, 0])).unwrap(); // 0 as sentinel (self-loop)

--- a/src/edgelist/edge_list.rs
+++ b/src/edgelist/edge_list.rs
@@ -173,14 +173,13 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::edges::EdgeNodeError;
-    use crate::graph::{GraphError, GraphWithEdgeValues, GraphWithMutableEdges};
-    use crate::tests::{collect, collect_sorted};
     use crate::adjacency_list::map_adjacency_list::MapAdjacencyList;
     use crate::containers::maps::staticdict::Dictionary;
     use crate::containers::maps::MapTrait;
+    use crate::edges::EdgeNodeError;
     use crate::edges::EdgeStructOption;
-
+    use crate::graph::{GraphError, GraphWithEdgeValues, GraphWithMutableEdges};
+    use crate::tests::{collect, collect_sorted};
 
     #[test]
     fn test_edge_list_new() {
@@ -516,9 +515,6 @@ mod tests {
 
     #[test]
     fn test_edge_list_add_remove_edge_comprehensive() {
-        use crate::edges::EdgeStructOption;
-        use crate::graph::GraphWithMutableEdges;
-
         let edges = EdgeStructOption([None, None, None, None, None]);
         let mut graph = EdgeList::<10, usize, _>::new(edges);
 
@@ -558,9 +554,6 @@ mod tests {
 
     #[test]
     fn test_edge_list_self_loops() {
-        use crate::edges::EdgeStructOption;
-        use crate::graph::GraphWithMutableEdges;
-
         let edges = EdgeStructOption([None, None, None, None, None]);
         let mut graph = EdgeList::<10, usize, _>::new(edges);
 

--- a/src/edgelist/edge_list.rs
+++ b/src/edgelist/edge_list.rs
@@ -174,8 +174,13 @@ where
 mod tests {
     use super::*;
     use crate::edges::EdgeNodeError;
-    use crate::graph::{GraphError, GraphWithEdgeValues};
+    use crate::graph::{GraphError, GraphWithEdgeValues, GraphWithMutableEdges};
     use crate::tests::{collect, collect_sorted};
+    use crate::adjacency_list::map_adjacency_list::MapAdjacencyList;
+    use crate::containers::maps::staticdict::Dictionary;
+    use crate::containers::maps::MapTrait;
+    use crate::edges::EdgeStructOption;
+
 
     #[test]
     fn test_edge_list_new() {
@@ -410,9 +415,6 @@ mod tests {
 
     #[test]
     fn test_edge_list_add_edge_success() {
-        use crate::edges::EdgeStructOption;
-        use crate::graph::GraphWithMutableEdges;
-
         let edges = EdgeStructOption([None, None, None, None, None]); // Capacity for 5 edges
         let mut graph = EdgeList::<10, usize, _>::new(edges);
 
@@ -442,9 +444,6 @@ mod tests {
 
     #[test]
     fn test_edge_list_add_edge_capacity_exceeded() {
-        use crate::edges::EdgeStructOption;
-        use crate::graph::GraphWithMutableEdges;
-
         let edges = EdgeStructOption([None, None]); // Capacity for only 2 edges
         let mut graph = EdgeList::<10, usize, _>::new(edges);
 
@@ -462,9 +461,6 @@ mod tests {
 
     #[test]
     fn test_edge_list_remove_edge_success() {
-        use crate::edges::EdgeStructOption;
-        use crate::graph::GraphWithMutableEdges;
-
         let edges = EdgeStructOption([Some((0, 1)), Some((1, 2)), Some((0, 2)), None, None]);
         let mut graph = EdgeList::<10, usize, _>::new(edges);
 
@@ -487,9 +483,6 @@ mod tests {
 
     #[test]
     fn test_edge_list_remove_edge_isolates_node() {
-        use crate::edges::EdgeStructOption;
-        use crate::graph::GraphWithMutableEdges;
-
         let edges = EdgeStructOption([Some((0, 1)), Some((1, 2)), None, None, None]);
         let mut graph = EdgeList::<10, usize, _>::new(edges);
 
@@ -507,9 +500,6 @@ mod tests {
 
     #[test]
     fn test_edge_list_remove_edge_not_found() {
-        use crate::edges::EdgeStructOption;
-        use crate::graph::GraphWithMutableEdges;
-
         let edges = EdgeStructOption([Some((0, 1)), Some((1, 2)), None, None, None]);
         let mut graph = EdgeList::<10, usize, _>::new(edges);
 
@@ -590,11 +580,6 @@ mod tests {
 
     #[test]
     fn test_edge_list_from_graph() {
-        use crate::adjacency_list::map_adjacency_list::MapAdjacencyList;
-        use crate::containers::maps::staticdict::Dictionary;
-        use crate::containers::maps::MapTrait;
-        use crate::edges::EdgeStructOption;
-
         // Create a source graph (adjacency list)
         let mut dict = Dictionary::<usize, [usize; 2], 8>::new();
         dict.insert(0, [1, 2]).unwrap();
@@ -608,22 +593,11 @@ mod tests {
         // Verify edges were copied correctly - use collect to slice
         let mut edges = [(0usize, 0usize); 16];
         let edges_slice = collect(edge_list.iter_edges().unwrap(), &mut edges);
-        assert_eq!(edges_slice.len(), 4); // Should have 4 edges total
-
-        // Check that all expected edges are present
-        assert!(edges_slice.contains(&(0, 1)));
-        assert!(edges_slice.contains(&(0, 2)));
-        assert!(edges_slice.contains(&(1, 2)));
-        assert!(edges_slice.contains(&(1, 0)));
+        assert_eq!(edges_slice, &[(0, 1), (0, 2), (1, 2), (1, 0)]);
     }
 
     #[test]
     fn test_edge_list_from_empty_graph() {
-        use crate::adjacency_list::map_adjacency_list::MapAdjacencyList;
-        use crate::containers::maps::staticdict::Dictionary;
-        use crate::containers::maps::MapTrait;
-        use crate::edges::EdgeStructOption;
-
         // Create an empty source graph
         let dict = Dictionary::<usize, [usize; 2], 8>::new();
         let source = MapAdjacencyList::new_unchecked(dict);

--- a/src/edgelist/edge_node_list.rs
+++ b/src/edgelist/edge_node_list.rs
@@ -46,6 +46,77 @@ impl<NI, E, N> EdgeNodeList<NI, E, N> {
     }
 }
 
+impl<NI, E, N> EdgeNodeList<NI, E, N>
+where
+    NI: NodeIndex + Copy + Default,
+    E: crate::edges::EdgesIterable<Node = NI> + crate::edges::MutableEdges<NI> + Default,
+    N: crate::nodes::NodesIterable<Node = NI> + crate::nodes::MutableNodes<NI> + Default,
+{
+    /// Creates an EdgeNodeList from any graph by copying all nodes and edges
+    ///
+    /// This function iterates over all nodes and edges in the source graph and creates
+    /// an EdgeNodeList representation. Both nodes and edges are stored explicitly.
+    ///
+    /// # Arguments
+    /// * `source_graph` - The graph to copy nodes and edges from
+    ///
+    /// # Returns
+    /// * `Ok(EdgeNodeList)` if successful
+    /// * `Err(GraphError)` if iteration fails or capacity is exceeded
+    ///
+    /// # Constraints
+    /// * Node index type must implement Copy
+    /// * Edge container E must implement Default and MutableEdges
+    /// * Node container N must implement Default and MutableNodes
+    /// * Requires sufficient capacity in both E and N for all edges and nodes
+    ///
+    /// # Example
+    /// ```
+    /// use heapless_graphs::edgelist::edge_node_list::EdgeNodeList;
+    /// use heapless_graphs::adjacency_list::map_adjacency_list::MapAdjacencyList;
+    /// use heapless_graphs::containers::maps::staticdict::Dictionary;
+    /// use heapless_graphs::containers::maps::MapTrait;
+    /// use heapless_graphs::edges::EdgeStructOption;
+    /// use heapless_graphs::nodes::NodeStructOption;
+    ///
+    /// // Create a source graph (adjacency list)
+    /// let mut dict = Dictionary::<usize, [usize; 2], 8>::new();
+    /// dict.insert(0, [1, 2]).unwrap();
+    /// dict.insert(1, [2, 0]).unwrap();
+    /// dict.insert(2, [0, 1]).unwrap();
+    /// let source = MapAdjacencyList::new_unchecked(dict);
+    ///
+    /// // Convert to EdgeNodeList with capacity for nodes and edges
+    /// let edge_node_graph: EdgeNodeList<usize, EdgeStructOption<8, usize>, NodeStructOption<4, usize>> =
+    ///     EdgeNodeList::from_graph(&source).unwrap();
+    /// ```
+    pub fn from_graph<G>(source_graph: &G) -> Result<Self, GraphError<NI>>
+    where
+        G: Graph<NI>,
+        GraphError<NI>: From<G::Error>,
+    {
+        // Create default containers for edges and nodes
+        let mut edges = E::default();
+        let mut nodes = N::default();
+
+        // Add all nodes to the node container
+        for node in source_graph.iter_nodes()? {
+            if nodes.add(node).is_none() {
+                return Err(GraphError::OutOfCapacity);
+            }
+        }
+
+        // Add all edges to the edge container
+        for (source, destination) in source_graph.iter_edges()? {
+            if edges.add_edge((source, destination)).is_none() {
+                return Err(GraphError::OutOfCapacity);
+            }
+        }
+
+        Ok(Self::new_unchecked(edges, nodes))
+    }
+}
+
 impl<NI, E, N> Graph<NI> for EdgeNodeList<NI, E, N>
 where
     NI: NodeIndex,
@@ -562,5 +633,199 @@ mod test {
         let mut edges = [(0usize, 0usize); 8];
         let sorted_edges = collect_sorted(graph.iter_edges().unwrap(), &mut edges);
         assert_eq!(sorted_edges, &[(0, 1), (0, 3), (1, 2), (2, 3)]);
+    }
+
+    #[test]
+    fn test_edge_node_list_from_graph() {
+        use crate::adjacency_list::map_adjacency_list::MapAdjacencyList;
+        use crate::containers::maps::staticdict::Dictionary;
+        use crate::containers::maps::MapTrait;
+        use crate::edges::EdgeStructOption;
+        use crate::nodes::NodeStructOption;
+
+        // Create a source graph (map adjacency list with nodes 0, 1, 2)
+        let mut dict = Dictionary::<usize, [usize; 2], 8>::new();
+        dict.insert(0, [1, 2]).unwrap(); // 0 -> 1, 2
+        dict.insert(1, [2, 0]).unwrap(); // 1 -> 2, 0
+        dict.insert(2, [0, 1]).unwrap(); // 2 -> 0, 1
+        let source = MapAdjacencyList::new_unchecked(dict);
+
+        // Convert to EdgeNodeList with capacity for nodes and edges
+        let edge_node_graph: EdgeNodeList<
+            usize,
+            EdgeStructOption<8, usize>,
+            NodeStructOption<4, usize>,
+        > = EdgeNodeList::from_graph(&source).unwrap();
+
+        // Verify nodes were copied correctly
+        let mut nodes = [0usize; 8];
+        let nodes_slice = collect_sorted(edge_node_graph.iter_nodes().unwrap(), &mut nodes);
+        assert_eq!(nodes_slice.len(), 3); // Should have 3 nodes
+        assert!(nodes_slice.contains(&0));
+        assert!(nodes_slice.contains(&1));
+        assert!(nodes_slice.contains(&2));
+
+        // Verify edges were copied correctly
+        let mut edges = [(0usize, 0usize); 16];
+        let edges_slice = collect(edge_node_graph.iter_edges().unwrap(), &mut edges);
+        assert_eq!(edges_slice.len(), 6); // Should have 6 edges total
+
+        // Check that all expected edges are present
+        assert!(edges_slice.contains(&(0, 1)));
+        assert!(edges_slice.contains(&(0, 2)));
+        assert!(edges_slice.contains(&(1, 2)));
+        assert!(edges_slice.contains(&(1, 0)));
+        assert!(edges_slice.contains(&(2, 0)));
+        assert!(edges_slice.contains(&(2, 1)));
+    }
+
+    #[test]
+    fn test_edge_node_list_from_graph_empty() {
+        use crate::adjacency_list::map_adjacency_list::MapAdjacencyList;
+        use crate::containers::maps::staticdict::Dictionary;
+        use crate::edges::EdgeStructOption;
+        use crate::nodes::NodeStructOption;
+
+        // Create an empty source graph
+        let dict = Dictionary::<usize, [usize; 2], 8>::default();
+        let source = MapAdjacencyList::new_unchecked(dict);
+
+        // Convert to EdgeNodeList
+        let edge_node_graph: EdgeNodeList<
+            usize,
+            EdgeStructOption<8, usize>,
+            NodeStructOption<4, usize>,
+        > = EdgeNodeList::from_graph(&source).unwrap();
+
+        // Verify no nodes or edges
+        assert_eq!(edge_node_graph.iter_nodes().unwrap().count(), 0);
+        assert_eq!(edge_node_graph.iter_edges().unwrap().count(), 0);
+    }
+
+    #[test]
+    fn test_edge_node_list_from_graph_node_capacity_exceeded() {
+        use crate::adjacency_list::map_adjacency_list::MapAdjacencyList;
+        use crate::containers::maps::staticdict::Dictionary;
+        use crate::containers::maps::MapTrait;
+        use crate::edges::EdgeStructOption;
+        use crate::nodes::NodeStructOption;
+
+        // Create a source graph with 4 nodes but target has capacity for only 2
+        let mut dict = Dictionary::<usize, [usize; 1], 8>::new();
+        dict.insert(0, [1]).unwrap();
+        dict.insert(1, [2]).unwrap();
+        dict.insert(2, [3]).unwrap();
+        dict.insert(3, [0]).unwrap();
+        let source = MapAdjacencyList::new_unchecked(dict);
+
+        // Try to convert to EdgeNodeList with capacity for only 2 nodes
+        let result: Result<
+            EdgeNodeList<usize, EdgeStructOption<8, usize>, NodeStructOption<2, usize>>,
+            _,
+        > = EdgeNodeList::from_graph(&source);
+
+        // Should fail because source has 4 nodes but target has capacity for only 2
+        assert!(matches!(result, Err(GraphError::OutOfCapacity)));
+    }
+
+    #[test]
+    fn test_edge_node_list_from_graph_edge_capacity_exceeded() {
+        use crate::adjacency_list::map_adjacency_list::MapAdjacencyList;
+        use crate::containers::maps::staticdict::Dictionary;
+        use crate::containers::maps::MapTrait;
+        use crate::edges::EdgeStructOption;
+        use crate::nodes::NodeStructOption;
+
+        // Create a source graph with 6 edges but target has capacity for only 4
+        let mut dict = Dictionary::<usize, [usize; 2], 8>::new();
+        dict.insert(0, [1, 2]).unwrap(); // 0 -> 1, 2 (2 edges)
+        dict.insert(1, [2, 0]).unwrap(); // 1 -> 2, 0 (2 edges)
+        dict.insert(2, [0, 1]).unwrap(); // 2 -> 0, 1 (2 edges)
+        let source = MapAdjacencyList::new_unchecked(dict);
+
+        // Try to convert to EdgeNodeList with capacity for only 4 edges
+        let result: Result<
+            EdgeNodeList<usize, EdgeStructOption<4, usize>, NodeStructOption<4, usize>>,
+            _,
+        > = EdgeNodeList::from_graph(&source);
+
+        // Should fail because source has 6 edges but target has capacity for only 4
+        assert!(matches!(result, Err(GraphError::OutOfCapacity)));
+    }
+
+    #[test]
+    fn test_edge_node_list_from_graph_single_node() {
+        use crate::adjacency_list::map_adjacency_list::MapAdjacencyList;
+        use crate::containers::maps::staticdict::Dictionary;
+        use crate::containers::maps::MapTrait;
+        use crate::edges::EdgeStructOption;
+        use crate::nodes::NodeStructOption;
+
+        // Create a source graph with a single node and self-loop
+        let mut dict = Dictionary::<usize, [usize; 1], 8>::new();
+        dict.insert(42, [42]).unwrap(); // Node 42 -> 42 (self-loop)
+        let source = MapAdjacencyList::new_unchecked(dict);
+
+        // Convert to EdgeNodeList
+        let edge_node_graph: EdgeNodeList<
+            usize,
+            EdgeStructOption<8, usize>,
+            NodeStructOption<4, usize>,
+        > = EdgeNodeList::from_graph(&source).unwrap();
+
+        // Verify single node
+        let mut nodes = [0usize; 4];
+        let nodes_slice = collect(edge_node_graph.iter_nodes().unwrap(), &mut nodes);
+        assert_eq!(nodes_slice, &[42]);
+
+        // Verify self-loop edge
+        let mut edges = [(0usize, 0usize); 4];
+        let edges_slice = collect(edge_node_graph.iter_edges().unwrap(), &mut edges);
+        assert_eq!(edges_slice, &[(42, 42)]);
+    }
+
+    #[test]
+    fn test_edge_node_list_from_graph_chain() {
+        use crate::adjacency_list::map_adjacency_list::MapAdjacencyList;
+        use crate::containers::maps::staticdict::Dictionary;
+        use crate::containers::maps::MapTrait;
+        use crate::edges::EdgeStructOption;
+        use crate::nodes::NodeStructOption;
+
+        // Create a source graph forming a partial chain: 0 -> 1 -> 2
+        // Node 3 will have a self-loop
+        let mut dict = Dictionary::<usize, [usize; 1], 8>::new();
+        dict.insert(0, [1]).unwrap(); // 0 -> 1
+        dict.insert(1, [2]).unwrap(); // 1 -> 2
+        dict.insert(2, [0]).unwrap(); // 2 -> 0 (cycle back)
+        let source = MapAdjacencyList::new_unchecked(dict);
+
+        // Convert to EdgeNodeList
+        let edge_node_graph: EdgeNodeList<
+            usize,
+            EdgeStructOption<8, usize>,
+            NodeStructOption<8, usize>,
+        > = EdgeNodeList::from_graph(&source).unwrap();
+
+        // Verify all nodes
+        let mut nodes = [0usize; 8];
+        let nodes_slice = collect_sorted(edge_node_graph.iter_nodes().unwrap(), &mut nodes);
+        assert_eq!(nodes_slice, &[0, 1, 2]);
+
+        // Verify edges
+        let mut edges = [(0usize, 0usize); 8];
+        let edges_slice = collect_sorted(edge_node_graph.iter_edges().unwrap(), &mut edges);
+        assert_eq!(edges_slice, &[(0, 1), (1, 2), (2, 0)]);
+
+        // Verify outgoing edges for each node
+        let mut outgoing = [0usize; 2];
+        let outgoing_slice = collect(edge_node_graph.outgoing_edges(0).unwrap(), &mut outgoing);
+        assert_eq!(outgoing_slice, &[1]);
+
+        let outgoing_slice = collect(edge_node_graph.outgoing_edges(1).unwrap(), &mut outgoing);
+        assert_eq!(outgoing_slice, &[2]);
+
+        let outgoing_slice = collect(edge_node_graph.outgoing_edges(2).unwrap(), &mut outgoing);
+        assert_eq!(outgoing_slice, &[0]);
     }
 }

--- a/src/edgelist/edge_node_list.rs
+++ b/src/edgelist/edge_node_list.rs
@@ -238,9 +238,15 @@ where
 mod test {
     use super::*;
     use crate::edges::EdgeValueStruct;
-    use crate::graph::{GraphError, GraphWithEdgeValues, GraphWithNodeValues};
+    use crate::graph::{GraphError, GraphWithEdgeValues, GraphWithNodeValues, GraphWithMutableEdges};
     use crate::nodes::{NodeValueStructOption, NodesValuesIterable};
     use crate::tests::{collect, collect_sorted};
+    use crate::adjacency_list::map_adjacency_list::MapAdjacencyList;
+    use crate::containers::maps::staticdict::Dictionary;
+    use crate::containers::maps::MapTrait;
+    use crate::edges::EdgeStructOption;
+    use crate::nodes::NodeStructOption;
+
 
     #[test]
     fn test_edge_node_list() {
@@ -326,8 +332,6 @@ mod test {
 
     #[test]
     fn test_add_node_to_empty_graph() {
-        use crate::nodes::NodeStructOption;
-
         let edges: [(usize, usize); 0] = [];
         let nodes = NodeStructOption([None, None, None]); // Capacity for 3 nodes
         let mut graph = EdgeNodeList::new(edges, nodes).unwrap();
@@ -343,8 +347,6 @@ mod test {
 
     #[test]
     fn test_add_node_to_existing_graph() {
-        use crate::nodes::NodeStructOption;
-
         let edges = [(0usize, 1usize), (1, 2)];
         let nodes = NodeStructOption([Some(0), Some(1), Some(2), None, None]); // Room to add more
         let mut graph = EdgeNodeList::new(edges, nodes).unwrap();
@@ -374,8 +376,6 @@ mod test {
 
     #[test]
     fn test_add_node_capacity_exceeded() {
-        use crate::nodes::NodeStructOption;
-
         // Create a NodeStructOption that's already at full capacity
         let edges = [(0usize, 1usize)];
         let nodes = NodeStructOption([Some(0), Some(1)]); // Full capacity, no None slots
@@ -393,8 +393,6 @@ mod test {
 
     #[test]
     fn test_add_multiple_nodes() {
-        use crate::nodes::NodeStructOption;
-
         let edges: [(usize, usize); 0] = [];
         let nodes = NodeStructOption([None, None, None, None, None]); // Capacity for 5 nodes
         let mut graph = EdgeNodeList::new(edges, nodes).unwrap();
@@ -421,8 +419,6 @@ mod test {
 
     #[test]
     fn test_add_duplicate_node() {
-        use crate::nodes::NodeStructOption;
-
         let edges = [(0usize, 1usize)];
         let nodes = NodeStructOption([Some(0), Some(1), None]);
         let mut graph = EdgeNodeList::new(edges, nodes).unwrap();
@@ -439,8 +435,6 @@ mod test {
 
     #[test]
     fn test_add_node_with_option_container() {
-        use crate::nodes::NodeStructOption;
-
         let edges = [(0usize, 1usize)];
         let nodes = NodeStructOption([Some(0), Some(1), None]);
         let mut graph = EdgeNodeList::new(edges, nodes).unwrap();
@@ -464,10 +458,6 @@ mod test {
 
     #[test]
     fn test_add_edge_success() {
-        use crate::edges::EdgeStructOption;
-        use crate::graph::GraphWithMutableEdges;
-        use crate::nodes::NodeStructOption;
-
         let edges = EdgeStructOption([None, None, None, None, None]); // Capacity for 5 edges
         let nodes = NodeStructOption([Some(0), Some(1), Some(2), None, None]); // 3 nodes
         let mut graph = EdgeNodeList::new(edges, nodes).unwrap();
@@ -489,10 +479,6 @@ mod test {
 
     #[test]
     fn test_add_edge_invalid_nodes() {
-        use crate::edges::EdgeStructOption;
-        use crate::graph::GraphWithMutableEdges;
-        use crate::nodes::NodeStructOption;
-
         let edges = EdgeStructOption([None, None, None, None, None]);
         let nodes = NodeStructOption([Some(0), Some(1), None, None, None]); // Only nodes 0, 1
         let mut graph = EdgeNodeList::new(edges, nodes).unwrap();
@@ -512,10 +498,6 @@ mod test {
 
     #[test]
     fn test_add_edge_capacity_exceeded() {
-        use crate::edges::EdgeStructOption;
-        use crate::graph::GraphWithMutableEdges;
-        use crate::nodes::NodeStructOption;
-
         let edges = EdgeStructOption([None, None]); // Capacity for only 2 edges
         let nodes = NodeStructOption([Some(0), Some(1), Some(2), None, None]);
         let mut graph = EdgeNodeList::new(edges, nodes).unwrap();
@@ -531,10 +513,6 @@ mod test {
 
     #[test]
     fn test_remove_edge_success() {
-        use crate::edges::EdgeStructOption;
-        use crate::graph::GraphWithMutableEdges;
-        use crate::nodes::NodeStructOption;
-
         let edges = EdgeStructOption([Some((0, 1)), Some((1, 2)), Some((0, 2)), None, None]);
         let nodes = NodeStructOption([Some(0), Some(1), Some(2), None, None]);
         let mut graph = EdgeNodeList::new(edges, nodes).unwrap();
@@ -554,10 +532,6 @@ mod test {
 
     #[test]
     fn test_remove_edge_not_found() {
-        use crate::edges::EdgeStructOption;
-        use crate::graph::GraphWithMutableEdges;
-        use crate::nodes::NodeStructOption;
-
         let edges = EdgeStructOption([Some((0, 1)), Some((1, 2)), None, None, None]);
         let nodes = NodeStructOption([Some(0), Some(1), Some(2), None, None]);
         let mut graph = EdgeNodeList::new(edges, nodes).unwrap();
@@ -572,10 +546,6 @@ mod test {
 
     #[test]
     fn test_remove_edge_with_nonexistent_nodes() {
-        use crate::edges::EdgeStructOption;
-        use crate::graph::GraphWithMutableEdges;
-        use crate::nodes::NodeStructOption;
-
         let edges = EdgeStructOption([Some((0, 1)), None, None, None, None]);
         let nodes = NodeStructOption([Some(0), Some(1), None, None, None]); // Only nodes 0, 1
         let mut graph = EdgeNodeList::new(edges, nodes).unwrap();
@@ -592,10 +562,6 @@ mod test {
 
     #[test]
     fn test_add_remove_edge_comprehensive() {
-        use crate::edges::EdgeStructOption;
-        use crate::graph::GraphWithMutableEdges;
-        use crate::nodes::NodeStructOption;
-
         let edges = EdgeStructOption([None, None, None, None, None]);
         let nodes = NodeStructOption([Some(0), Some(1), Some(2), Some(3), None]);
         let mut graph = EdgeNodeList::new(edges, nodes).unwrap();
@@ -630,12 +596,6 @@ mod test {
 
     #[test]
     fn test_edge_node_list_from_graph() {
-        use crate::adjacency_list::map_adjacency_list::MapAdjacencyList;
-        use crate::containers::maps::staticdict::Dictionary;
-        use crate::containers::maps::MapTrait;
-        use crate::edges::EdgeStructOption;
-        use crate::nodes::NodeStructOption;
-
         // Create a source graph (map adjacency list with nodes 0, 1, 2)
         let mut dict = Dictionary::<usize, [usize; 2], 8>::new();
         dict.insert(0, [1, 2]).unwrap(); // 0 -> 1, 2
@@ -653,32 +613,16 @@ mod test {
         // Verify nodes were copied correctly
         let mut nodes = [0usize; 8];
         let nodes_slice = collect_sorted(edge_node_graph.iter_nodes().unwrap(), &mut nodes);
-        assert_eq!(nodes_slice.len(), 3); // Should have 3 nodes
-        assert!(nodes_slice.contains(&0));
-        assert!(nodes_slice.contains(&1));
-        assert!(nodes_slice.contains(&2));
+        assert_eq!(nodes_slice, &[0, 1, 2]);
 
         // Verify edges were copied correctly
         let mut edges = [(0usize, 0usize); 16];
         let edges_slice = collect(edge_node_graph.iter_edges().unwrap(), &mut edges);
-        assert_eq!(edges_slice.len(), 6); // Should have 6 edges total
-
-        // Check that all expected edges are present
-        assert!(edges_slice.contains(&(0, 1)));
-        assert!(edges_slice.contains(&(0, 2)));
-        assert!(edges_slice.contains(&(1, 2)));
-        assert!(edges_slice.contains(&(1, 0)));
-        assert!(edges_slice.contains(&(2, 0)));
-        assert!(edges_slice.contains(&(2, 1)));
+        assert_eq!(edges_slice, &[(0, 1), (0, 2), (1, 2), (1, 0), (2, 0), (2, 1)]);
     }
 
     #[test]
     fn test_edge_node_list_from_graph_empty() {
-        use crate::adjacency_list::map_adjacency_list::MapAdjacencyList;
-        use crate::containers::maps::staticdict::Dictionary;
-        use crate::edges::EdgeStructOption;
-        use crate::nodes::NodeStructOption;
-
         // Create an empty source graph
         let dict = Dictionary::<usize, [usize; 2], 8>::default();
         let source = MapAdjacencyList::new_unchecked(dict);
@@ -697,12 +641,6 @@ mod test {
 
     #[test]
     fn test_edge_node_list_from_graph_node_capacity_exceeded() {
-        use crate::adjacency_list::map_adjacency_list::MapAdjacencyList;
-        use crate::containers::maps::staticdict::Dictionary;
-        use crate::containers::maps::MapTrait;
-        use crate::edges::EdgeStructOption;
-        use crate::nodes::NodeStructOption;
-
         // Create a source graph with 4 nodes but target has capacity for only 2
         let mut dict = Dictionary::<usize, [usize; 1], 8>::new();
         dict.insert(0, [1]).unwrap();
@@ -723,12 +661,6 @@ mod test {
 
     #[test]
     fn test_edge_node_list_from_graph_edge_capacity_exceeded() {
-        use crate::adjacency_list::map_adjacency_list::MapAdjacencyList;
-        use crate::containers::maps::staticdict::Dictionary;
-        use crate::containers::maps::MapTrait;
-        use crate::edges::EdgeStructOption;
-        use crate::nodes::NodeStructOption;
-
         // Create a source graph with 6 edges but target has capacity for only 4
         let mut dict = Dictionary::<usize, [usize; 2], 8>::new();
         dict.insert(0, [1, 2]).unwrap(); // 0 -> 1, 2 (2 edges)
@@ -748,12 +680,6 @@ mod test {
 
     #[test]
     fn test_edge_node_list_from_graph_single_node() {
-        use crate::adjacency_list::map_adjacency_list::MapAdjacencyList;
-        use crate::containers::maps::staticdict::Dictionary;
-        use crate::containers::maps::MapTrait;
-        use crate::edges::EdgeStructOption;
-        use crate::nodes::NodeStructOption;
-
         // Create a source graph with a single node and self-loop
         let mut dict = Dictionary::<usize, [usize; 1], 8>::new();
         dict.insert(42, [42]).unwrap(); // Node 42 -> 42 (self-loop)
@@ -779,12 +705,6 @@ mod test {
 
     #[test]
     fn test_edge_node_list_from_graph_chain() {
-        use crate::adjacency_list::map_adjacency_list::MapAdjacencyList;
-        use crate::containers::maps::staticdict::Dictionary;
-        use crate::containers::maps::MapTrait;
-        use crate::edges::EdgeStructOption;
-        use crate::nodes::NodeStructOption;
-
         // Create a source graph forming a partial chain: 0 -> 1 -> 2
         // Node 3 will have a self-loop
         let mut dict = Dictionary::<usize, [usize; 1], 8>::new();

--- a/src/edgelist/edge_node_list.rs
+++ b/src/edgelist/edge_node_list.rs
@@ -237,16 +237,17 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::edges::EdgeValueStruct;
-    use crate::graph::{GraphError, GraphWithEdgeValues, GraphWithNodeValues, GraphWithMutableEdges};
-    use crate::nodes::{NodeValueStructOption, NodesValuesIterable};
-    use crate::tests::{collect, collect_sorted};
     use crate::adjacency_list::map_adjacency_list::MapAdjacencyList;
     use crate::containers::maps::staticdict::Dictionary;
     use crate::containers::maps::MapTrait;
     use crate::edges::EdgeStructOption;
+    use crate::edges::EdgeValueStruct;
+    use crate::graph::{
+        GraphError, GraphWithEdgeValues, GraphWithMutableEdges, GraphWithNodeValues,
+    };
     use crate::nodes::NodeStructOption;
-
+    use crate::nodes::{NodeValueStructOption, NodesValuesIterable};
+    use crate::tests::{collect, collect_sorted};
 
     #[test]
     fn test_edge_node_list() {
@@ -618,7 +619,10 @@ mod test {
         // Verify edges were copied correctly
         let mut edges = [(0usize, 0usize); 16];
         let edges_slice = collect(edge_node_graph.iter_edges().unwrap(), &mut edges);
-        assert_eq!(edges_slice, &[(0, 1), (0, 2), (1, 2), (1, 0), (2, 0), (2, 1)]);
+        assert_eq!(
+            edges_slice,
+            &[(0, 1), (0, 2), (1, 2), (1, 0), (2, 0), (2, 1)]
+        );
     }
 
     #[test]

--- a/src/edgelist/edge_node_list.rs
+++ b/src/edgelist/edge_node_list.rs
@@ -71,25 +71,18 @@ where
     /// * Requires sufficient capacity in both E and N for all edges and nodes
     ///
     /// # Example
-    /// ```
-    /// use heapless_graphs::edgelist::edge_node_list::EdgeNodeList;
-    /// use heapless_graphs::adjacency_list::map_adjacency_list::MapAdjacencyList;
-    /// use heapless_graphs::containers::maps::staticdict::Dictionary;
-    /// use heapless_graphs::containers::maps::MapTrait;
-    /// use heapless_graphs::edges::EdgeStructOption;
-    /// use heapless_graphs::nodes::NodeStructOption;
+    /// # use heapless_graphs::edgelist::edge_node_list::EdgeNodeList;
+    /// # use heapless_graphs::edgelist::edge_list::EdgeList;
+    /// # use heapless_graphs::edges::EdgeStructOption;
+    /// # use heapless_graphs::nodes::NodeStructOption;
     ///
-    /// // Create a source graph (adjacency list)
-    /// let mut dict = Dictionary::<usize, [usize; 2], 8>::new();
-    /// dict.insert(0, [1, 2]).unwrap();
-    /// dict.insert(1, [2, 0]).unwrap();
-    /// dict.insert(2, [0, 1]).unwrap();
-    /// let source = MapAdjacencyList::new_unchecked(dict);
+    /// // Create a source graph (edge list)
+    /// let edges = EdgeStructOption([Some((0, 1)), Some((1, 2)), Some((0, 2)), None]);
+    /// let source = EdgeList::<4, usize, _>::new(edges);
     ///
     /// // Convert to EdgeNodeList with capacity for nodes and edges
-    /// let edge_node_graph: EdgeNodeList<usize, EdgeStructOption<8, usize>, NodeStructOption<4, usize>> =
+    /// let edge_node_graph: EdgeNodeList<usize, EdgeStructOption<8, _>, NodeStructOption<4, _>> =
     ///     EdgeNodeList::from_graph(&source).unwrap();
-    /// ```
     pub fn from_graph<G>(source_graph: &G) -> Result<Self, GraphError<NI>>
     where
         G: Graph<NI>,

--- a/src/matrix/bit_map_matrix.rs
+++ b/src/matrix/bit_map_matrix.rs
@@ -338,6 +338,9 @@ where
 mod tests {
     use super::*;
     use crate::containers::maps::staticdict::Dictionary;
+    use crate::edgelist::edge_list::EdgeList;
+    use crate::edges::EdgeStructOption;
+    use crate::graph::GraphWithMutableEdges;
     use crate::tests::{collect, collect_sorted};
 
     #[test]
@@ -610,8 +613,6 @@ mod tests {
 
     #[test]
     fn test_add_edge_success() {
-        use crate::graph::GraphWithMutableEdges;
-
         let bits = [[0u8]; 8];
         let bitmap = super::super::bit_matrix::BitMatrix::new_unchecked(bits);
         let mut index_map = Dictionary::<char, usize, 10>::new();
@@ -638,8 +639,6 @@ mod tests {
 
     #[test]
     fn test_add_edge_invalid_nodes() {
-        use crate::graph::GraphWithMutableEdges;
-
         let bits = [[0u8]; 8];
         let bitmap = super::super::bit_matrix::BitMatrix::new_unchecked(bits);
         let mut index_map = Dictionary::<char, usize, 10>::new();
@@ -663,8 +662,6 @@ mod tests {
 
     #[test]
     fn test_remove_edge_success() {
-        use crate::graph::GraphWithMutableEdges;
-
         // Set up matrix with some initial edges
         let bits = [
             [0b00000110u8], // A->B, A->C
@@ -699,8 +696,6 @@ mod tests {
 
     #[test]
     fn test_remove_edge_not_found() {
-        use crate::graph::GraphWithMutableEdges;
-
         let bits = [
             [0b00000010u8], // A->B
             [0b00000000u8],
@@ -733,8 +728,6 @@ mod tests {
 
     #[test]
     fn test_add_remove_edge_comprehensive() {
-        use crate::graph::GraphWithMutableEdges;
-
         let bits = [[0u8]; 8];
         let bitmap = super::super::bit_matrix::BitMatrix::new_unchecked(bits);
         let mut index_map = Dictionary::<u32, usize, 10>::new();
@@ -775,8 +768,6 @@ mod tests {
 
     #[test]
     fn test_self_loops() {
-        use crate::graph::GraphWithMutableEdges;
-
         let bits = [[0u8]; 8];
         let bitmap = super::super::bit_matrix::BitMatrix::new_unchecked(bits);
         let mut index_map = Dictionary::<char, usize, 10>::new();
@@ -804,8 +795,6 @@ mod tests {
 
     #[test]
     fn test_edge_idempotency() {
-        use crate::graph::GraphWithMutableEdges;
-
         let bits = [[0u8]; 8];
         let bitmap = super::super::bit_matrix::BitMatrix::new_unchecked(bits);
         let mut index_map = Dictionary::<u32, usize, 10>::new();
@@ -825,9 +814,6 @@ mod tests {
 
     #[test]
     fn test_bit_map_matrix_from_graph() {
-        use crate::edgelist::edge_list::EdgeList;
-        use crate::edges::EdgeStructOption;
-
         // Create a source graph (edge list with nodes 10, 20, 30)
         let edges = EdgeStructOption([Some((10, 20)), Some((20, 30)), Some((10, 30)), None]);
         let source = EdgeList::<4, usize, _>::new(edges);
@@ -855,9 +841,6 @@ mod tests {
 
     #[test]
     fn test_bit_map_matrix_from_graph_capacity_exceeded() {
-        use crate::edgelist::edge_list::EdgeList;
-        use crate::edges::EdgeStructOption;
-
         // Create a source graph with 9 nodes but BitMatrix<1,8> only supports 8
         let edges = EdgeStructOption([
             Some((0, 1)),
@@ -881,9 +864,6 @@ mod tests {
 
     #[test]
     fn test_bit_map_matrix_from_graph_with_arbitrary_indices() {
-        use crate::edgelist::edge_list::EdgeList;
-        use crate::edges::EdgeStructOption;
-
         // Create a source graph with non-contiguous node indices
         let edges = EdgeStructOption([Some((100, 200)), Some((200, 500)), Some((500, 100)), None]);
         let source = EdgeList::<4, usize, _>::new(edges);
@@ -916,9 +896,6 @@ mod tests {
 
     #[test]
     fn test_bit_map_matrix_from_graph_invalid_dimensions() {
-        use crate::edgelist::edge_list::EdgeList;
-        use crate::edges::EdgeStructOption;
-
         // Create a source graph
         let edges = EdgeStructOption([Some((0, 1)), Some((1, 2)), None]);
         let source = EdgeList::<3, usize, _>::new(edges);

--- a/src/matrix/bit_map_matrix.rs
+++ b/src/matrix/bit_map_matrix.rs
@@ -913,4 +913,22 @@ mod tests {
         let outgoing_slice = collect(bit_map_matrix.outgoing_edges(500).unwrap(), &mut outgoing);
         assert_eq!(outgoing_slice, &[100]);
     }
+
+    #[test]
+    fn test_bit_map_matrix_from_graph_invalid_dimensions() {
+        use crate::edgelist::edge_list::EdgeList;
+        use crate::edges::EdgeStructOption;
+
+        // Create a source graph
+        let edges = EdgeStructOption([Some((0, 1)), Some((1, 2)), None]);
+        let source = EdgeList::<3, usize, _>::new(edges);
+
+        // Try to create BitMapMatrix with invalid dimensions (R ≠ 8*N)
+        // N=1, R=4, but 4 ≠ 8*1
+        type InvalidMatrix = BitMapMatrix<1, 4, usize, Dictionary<usize, usize, 8>>;
+        let result: Result<InvalidMatrix, _> = BitMapMatrix::from_graph(&source);
+
+        // Should fail with InvalidMatrixSize because R ≠ 8*N
+        assert!(matches!(result, Err(GraphError::InvalidMatrixSize)));
+    }
 }

--- a/src/matrix/bit_map_matrix.rs
+++ b/src/matrix/bit_map_matrix.rs
@@ -80,20 +80,18 @@ where
     /// * Map M must have sufficient capacity for all nodes
     ///
     /// # Example
-    /// ```
-    /// use heapless_graphs::matrix::bit_map_matrix::BitMapMatrix;
-    /// use heapless_graphs::edgelist::edge_list::EdgeList;
-    /// use heapless_graphs::edges::EdgeStructOption;
-    /// use heapless_graphs::containers::maps::staticdict::Dictionary;
+    /// # use heapless_graphs::matrix::bit_map_matrix::BitMapMatrix;
+    /// # use heapless_graphs::edgelist::edge_list::EdgeList;
+    /// # use heapless_graphs::edges::EdgeStructOption;
+    /// # use heapless_graphs::containers::maps::staticdict::Dictionary;
     ///
     /// // Create a source graph (edge list)
     /// let edges = EdgeStructOption([Some((0, 1)), Some((1, 2)), Some((0, 2)), None]);
     /// let source = EdgeList::<4, usize, _>::new(edges);
     ///
     /// // Convert to BitMapMatrix (8 nodes capacity)
-    /// let bit_map_matrix: BitMapMatrix<1, 8, usize, Dictionary<usize, usize, 8>> =
+    /// let bit_map_matrix: BitMapMatrix<1, 8, usize, Dictionary<_, _, 8>> =
     ///     BitMapMatrix::from_graph(&source).unwrap();
-    /// ```
     pub fn from_graph<G>(source_graph: &G) -> Result<Self, GraphError<NI>>
     where
         G: Graph<NI>,
@@ -132,9 +130,12 @@ where
         if let Ok(edges_iter) = source_graph.iter_edges() {
             for (src, dst) in edges_iter {
                 // Look up matrix indices for both source and destination
-                if let (Some(&src_idx), Some(&dst_idx)) = (index_map.get(&src), index_map.get(&dst)) {
+                if let (Some(&src_idx), Some(&dst_idx)) = (index_map.get(&src), index_map.get(&dst))
+                {
                     // Add edge using matrix indices
-                    bitmap.add_edge(src_idx, dst_idx).map_err(|_| GraphError::OutOfCapacity)?;
+                    bitmap
+                        .add_edge(src_idx, dst_idx)
+                        .map_err(|_| GraphError::OutOfCapacity)?;
                 }
                 // If we can't find indices for either node, skip the edge
             }
@@ -143,7 +144,6 @@ where
         Ok(Self::new_unchecked(bitmap, index_map))
     }
 }
-
 
 impl<const N: usize, const R: usize, NI, M> Graph<NI> for BitMapMatrix<N, R, NI, M>
 where

--- a/src/matrix/bit_map_matrix.rs
+++ b/src/matrix/bit_map_matrix.rs
@@ -95,6 +95,7 @@ where
     pub fn from_graph<G>(source_graph: &G) -> Result<Self, GraphError<NI>>
     where
         G: Graph<NI>,
+        GraphError<NI>: From<G::Error>,
     {
         // Create default storage for index map
         let mut index_map = M::default();
@@ -102,7 +103,8 @@ where
         // Collect all nodes and assign bit matrix indices
         let max_index = 8 * N; // BitMatrix supports 0..8*N
 
-        // Handle the case where iter_nodes() fails (e.g., empty EdgeList)
+        // Collect all nodes and assign bit matrix indices
+        // Properly handle errors from iter_nodes() while supporting empty graphs
         match source_graph.iter_nodes() {
             Ok(nodes_iter) => {
                 for (matrix_index, node) in nodes_iter.enumerate() {
@@ -116,9 +118,19 @@ where
                         .map_err(|_| GraphError::OutOfCapacity)?;
                 }
             }
-            Err(_) => {
-                // If iter_nodes() fails (e.g., empty EdgeList), we'll create an empty matrix
-                // This is valid - the matrix will have no nodes mapped
+            Err(err) => {
+                // Convert error to our error type to examine it
+                let graph_error = GraphError::from(err);
+                match graph_error {
+                    GraphError::OutOfCapacity => {
+                        // This is likely an EmptyEdges error from EdgeList - treat as empty graph
+                        // Creating an empty matrix with no nodes mapped is valid for empty graphs
+                    }
+                    other_error => {
+                        // Propagate genuine errors (invalid state, iteration failures, etc.)
+                        return Err(other_error);
+                    }
+                }
             }
         }
 

--- a/src/matrix/bit_matrix.rs
+++ b/src/matrix/bit_matrix.rs
@@ -223,8 +223,11 @@ impl<const C: usize, const R: usize> GraphWithMutableEdges<usize> for BitMatrix<
 
 #[cfg(test)]
 mod tests {
-
     use super::*;
+    use crate::adjacency_list::map_adjacency_list::MapAdjacencyList;
+    use crate::containers::maps::staticdict::Dictionary;
+    use crate::containers::maps::MapTrait;
+    use crate::graph::GraphWithMutableEdges;
     use crate::tests::{collect, collect_sorted};
 
     #[test]
@@ -652,8 +655,6 @@ mod tests {
 
     #[test]
     fn test_bit_matrix_add_edge_success() {
-        use crate::graph::GraphWithMutableEdges;
-
         let bits = [
             [0b00000000u8], // Initially no edges
             [0b00000000u8],
@@ -688,8 +689,6 @@ mod tests {
 
     #[test]
     fn test_bit_matrix_add_edge_invalid_nodes() {
-        use crate::graph::GraphWithMutableEdges;
-
         let bits = [[0b00000000u8]; 8];
         let mut matrix = BitMatrix::new_unchecked(bits);
 
@@ -708,8 +707,6 @@ mod tests {
 
     #[test]
     fn test_bit_matrix_remove_edge_success() {
-        use crate::graph::GraphWithMutableEdges;
-
         let bits = [
             [0b00001010u8], // 0->1, 0->3
             [0b00000100u8], // 1->2
@@ -743,8 +740,6 @@ mod tests {
 
     #[test]
     fn test_bit_matrix_remove_edge_not_found() {
-        use crate::graph::GraphWithMutableEdges;
-
         let bits = [
             [0b00000010u8], // 0->1
             [0b00000000u8],
@@ -772,8 +767,6 @@ mod tests {
 
     #[test]
     fn test_bit_matrix_add_remove_edge_comprehensive() {
-        use crate::graph::GraphWithMutableEdges;
-
         let bits = [[0b00000000u8]; 8];
         let mut matrix = BitMatrix::new_unchecked(bits);
 
@@ -807,8 +800,6 @@ mod tests {
 
     #[test]
     fn test_bit_matrix_self_loops() {
-        use crate::graph::GraphWithMutableEdges;
-
         let bits = [[0b00000000u8]; 8];
         let mut matrix = BitMatrix::new_unchecked(bits);
 
@@ -831,8 +822,6 @@ mod tests {
 
     #[test]
     fn test_bit_matrix_edge_overwrite() {
-        use crate::graph::GraphWithMutableEdges;
-
         let bits = [[0b00000000u8]; 8];
         let mut matrix = BitMatrix::new_unchecked(bits);
 
@@ -849,10 +838,6 @@ mod tests {
 
     #[test]
     fn test_bit_matrix_from_graph() {
-        use crate::adjacency_list::map_adjacency_list::MapAdjacencyList;
-        use crate::containers::maps::staticdict::Dictionary;
-        use crate::containers::maps::MapTrait;
-
         // Create a source graph (map adjacency list with nodes 0, 1, 2)
         let mut dict = Dictionary::<usize, [usize; 2], 8>::new();
         dict.insert(0, [1, 2]).unwrap(); // 0 -> 1, 2
@@ -870,14 +855,14 @@ mod tests {
         // Verify edges were copied correctly
         let mut edges = [(0usize, 0usize); 16];
         let edges_slice = collect_sorted(matrix.iter_edges().unwrap(), &mut edges);
-        assert_eq!(edges_slice, &[(0, 1), (0, 2), (1, 0), (1, 2), (2, 0), (2, 1)]);
+        assert_eq!(
+            edges_slice,
+            &[(0, 1), (0, 2), (1, 0), (1, 2), (2, 0), (2, 1)]
+        );
     }
 
     #[test]
     fn test_bit_matrix_from_graph_empty() {
-        use crate::adjacency_list::map_adjacency_list::MapAdjacencyList;
-        use crate::containers::maps::staticdict::Dictionary;
-
         // Create an empty source graph
         let dict = Dictionary::<usize, [usize; 2], 8>::default();
         let source = MapAdjacencyList::new_unchecked(dict);
@@ -892,10 +877,6 @@ mod tests {
 
     #[test]
     fn test_bit_matrix_from_graph_node_out_of_range() {
-        use crate::adjacency_list::map_adjacency_list::MapAdjacencyList;
-        use crate::containers::maps::staticdict::Dictionary;
-        use crate::containers::maps::MapTrait;
-
         // Create a source graph with node index too large for 1-column matrix (8 nodes max)
         let mut dict = Dictionary::<usize, [usize; 1], 8>::new();
         dict.insert(0, [1]).unwrap();
@@ -911,10 +892,6 @@ mod tests {
 
     #[test]
     fn test_bit_matrix_from_graph_single_node() {
-        use crate::adjacency_list::map_adjacency_list::MapAdjacencyList;
-        use crate::containers::maps::staticdict::Dictionary;
-        use crate::containers::maps::MapTrait;
-
         // Create a source graph with a single node and self-loop
         let mut dict = Dictionary::<usize, [usize; 1], 8>::new();
         dict.insert(5, [5]).unwrap(); // Node 5 -> 5 (self-loop)
@@ -934,10 +911,6 @@ mod tests {
 
     #[test]
     fn test_bit_matrix_from_graph_larger_matrix() {
-        use crate::adjacency_list::map_adjacency_list::MapAdjacencyList;
-        use crate::containers::maps::staticdict::Dictionary;
-        use crate::containers::maps::MapTrait;
-
         // Create a source graph that uses higher node indices
         let mut dict = Dictionary::<usize, [usize; 2], 8>::new();
         dict.insert(8, [9, 10]).unwrap(); // Node 8 -> 9, 10

--- a/src/matrix/bit_matrix.rs
+++ b/src/matrix/bit_matrix.rs
@@ -108,19 +108,15 @@ impl<const C: usize, const R: usize> BitMatrix<C, R> {
     ///
     /// # Example
     /// ```
-    /// use heapless_graphs::matrix::bit_matrix::BitMatrix;
-    /// use heapless_graphs::adjacency_list::map_adjacency_list::MapAdjacencyList;
-    /// use heapless_graphs::containers::maps::staticdict::Dictionary;
-    /// use heapless_graphs::containers::maps::MapTrait;
+    /// # use heapless_graphs::matrix::bit_matrix::BitMatrix;
+    /// # use heapless_graphs::edgelist::edge_list::EdgeList;
+    /// # use heapless_graphs::edges::EdgeStructOption;
     ///
-    /// // Create a source graph (adjacency list)
-    /// let mut dict = Dictionary::<usize, [usize; 2], 8>::new();
-    /// dict.insert(0, [1, 2]).unwrap();
-    /// dict.insert(1, [2, 0]).unwrap();
-    /// dict.insert(2, [0, 1]).unwrap();
-    /// let source = MapAdjacencyList::new_unchecked(dict);
+    /// // Create a source graph (edge list)
+    /// let edges = EdgeStructOption([Some((0, 1)), Some((1, 2)), Some((0, 2)), None]);
+    /// let source = EdgeList::<4, usize, _>::new(edges);
     ///
-    /// // Convert to BitMatrix (1 column for 8 nodes: 8 = 8*1)
+    /// // Convert to BitMatrix (8 nodes capacity)
     /// let matrix: BitMatrix<1, 8> = BitMatrix::from_graph(&source).unwrap();
     /// ```
     pub fn from_graph<G>(source_graph: &G) -> Result<Self, GraphError<usize>>

--- a/src/matrix/bit_matrix.rs
+++ b/src/matrix/bit_matrix.rs
@@ -869,16 +869,8 @@ mod tests {
 
         // Verify edges were copied correctly
         let mut edges = [(0usize, 0usize); 16];
-        let edges_slice = collect(matrix.iter_edges().unwrap(), &mut edges);
-        assert_eq!(edges_slice.len(), 6); // Should have 6 edges total
-
-        // Check that all expected edges are present
-        assert!(edges_slice.contains(&(0, 1)));
-        assert!(edges_slice.contains(&(0, 2)));
-        assert!(edges_slice.contains(&(1, 2)));
-        assert!(edges_slice.contains(&(1, 0)));
-        assert!(edges_slice.contains(&(2, 0)));
-        assert!(edges_slice.contains(&(2, 1)));
+        let edges_slice = collect_sorted(matrix.iter_edges().unwrap(), &mut edges);
+        assert_eq!(edges_slice, &[(0, 1), (0, 2), (1, 0), (1, 2), (2, 0), (2, 1)]);
     }
 
     #[test]

--- a/src/matrix/map_matrix.rs
+++ b/src/matrix/map_matrix.rs
@@ -81,20 +81,18 @@ where
     /// * Map M must have sufficient capacity for all nodes
     ///
     /// # Example
-    /// ```
-    /// use heapless_graphs::matrix::map_matrix::MapMatrix;
-    /// use heapless_graphs::edgelist::edge_list::EdgeList;
-    /// use heapless_graphs::edges::EdgeStructOption;
-    /// use heapless_graphs::containers::maps::staticdict::Dictionary;
+    /// # use heapless_graphs::matrix::map_matrix::MapMatrix;
+    /// # use heapless_graphs::edgelist::edge_list::EdgeList;
+    /// # use heapless_graphs::edges::EdgeStructOption;
+    /// # use heapless_graphs::containers::maps::staticdict::Dictionary;
     ///
     /// // Create a source graph (edge list)
     /// let edges = EdgeStructOption([Some((0, 1)), Some((1, 2)), Some((0, 2)), None]);
     /// let source = EdgeList::<4, usize, _>::new(edges);
     ///
     /// // Convert to MapMatrix (3x3 matrix to fit nodes 0, 1, 2)
-    /// let map_matrix: MapMatrix<3, usize, (), Dictionary<usize, usize, 8>, [[Option<()>; 3]; 3], [Option<()>; 3]> =
+    /// let map_matrix: MapMatrix<3, usize, (), Dictionary<_, _, 8>, [[Option<()>; 3]; 3], _> =
     ///     MapMatrix::from_graph(&source).unwrap();
-    /// ```
     pub fn from_graph<G>(source_graph: &G) -> Result<Self, GraphError<NI>>
     where
         G: Graph<NI>,
@@ -124,15 +122,19 @@ where
         }
 
         // Create empty matrix and populate it with mapped edges
-        let mut inner_matrix = super::simple_matrix::Matrix::<N, EDGEVALUE, COLUMNS, ROW>::new(COLUMNS::default());
+        let mut inner_matrix =
+            super::simple_matrix::Matrix::<N, EDGEVALUE, COLUMNS, ROW>::new(COLUMNS::default());
 
         // Add all edges using mapped indices
         if let Ok(edges_iter) = source_graph.iter_edges() {
             for (src, dst) in edges_iter {
                 // Look up matrix indices for both source and destination
-                if let (Some(&src_idx), Some(&dst_idx)) = (index_map.get(&src), index_map.get(&dst)) {
+                if let (Some(&src_idx), Some(&dst_idx)) = (index_map.get(&src), index_map.get(&dst))
+                {
                     // Add edge using matrix indices
-                    inner_matrix.add_edge(src_idx, dst_idx).map_err(|_| GraphError::OutOfCapacity)?;
+                    inner_matrix
+                        .add_edge(src_idx, dst_idx)
+                        .map_err(|_| GraphError::OutOfCapacity)?;
                 }
                 // If we can't find indices for either node, skip the edge
             }
@@ -145,7 +147,6 @@ where
         })
     }
 }
-
 
 impl<const N: usize, NI, EDGEVALUE, M, COLUMNS, ROW> Graph<NI>
     for MapMatrix<N, NI, EDGEVALUE, M, COLUMNS, ROW>

--- a/src/matrix/map_matrix.rs
+++ b/src/matrix/map_matrix.rs
@@ -377,7 +377,10 @@ where
 mod tests {
     use super::*;
     use crate::containers::maps::staticdict::Dictionary;
+    use crate::edgelist::edge_list::EdgeList;
+    use crate::edges::EdgeStructOption;
     use crate::graph::GraphWithEdgeValues;
+    use crate::graph::GraphWithMutableEdges;
     use crate::tests::{collect, collect_sorted};
 
     #[test]
@@ -900,8 +903,6 @@ mod tests {
 
     #[test]
     fn test_add_edge_success() {
-        use crate::graph::GraphWithMutableEdges;
-
         let matrix = [[None, None, None], [None, None, None], [None, None, None]];
         let mut index_map = Dictionary::<char, usize, 5>::new();
         index_map.insert('A', 0).unwrap();
@@ -935,8 +936,6 @@ mod tests {
 
     #[test]
     fn test_add_edge_invalid_nodes() {
-        use crate::graph::GraphWithMutableEdges;
-
         let matrix = [[None, None], [None, None]];
         let mut index_map = Dictionary::<char, usize, 5>::new();
         index_map.insert('A', 0).unwrap();
@@ -967,8 +966,6 @@ mod tests {
 
     #[test]
     fn test_remove_edge_success() {
-        use crate::graph::GraphWithMutableEdges;
-
         // Set up matrix with some initial edges
         let matrix = [
             [Some(1), Some(2), Some(3)], // A->A, A->B, A->C
@@ -1005,8 +1002,6 @@ mod tests {
 
     #[test]
     fn test_remove_edge_not_found() {
-        use crate::graph::GraphWithMutableEdges;
-
         let matrix = [
             [Some(1), None, None],
             [None, None, None],
@@ -1041,8 +1036,6 @@ mod tests {
 
     #[test]
     fn test_add_remove_edge_comprehensive() {
-        use crate::graph::GraphWithMutableEdges;
-
         let matrix = [
             [None, None, None, None],
             [None, None, None, None],
@@ -1095,8 +1088,6 @@ mod tests {
 
     #[test]
     fn test_self_loops() {
-        use crate::graph::GraphWithMutableEdges;
-
         let matrix = [[None, None], [None, None]];
         let mut index_map = Dictionary::<char, usize, 5>::new();
         index_map.insert('A', 0).unwrap();
@@ -1131,8 +1122,6 @@ mod tests {
 
     #[test]
     fn test_edge_overwrite() {
-        use crate::graph::GraphWithMutableEdges;
-
         let matrix = [[Some(5), None], [None, None]];
         let mut index_map = Dictionary::<u32, usize, 5>::new();
         index_map.insert(1, 0).unwrap();
@@ -1163,9 +1152,6 @@ mod tests {
 
     #[test]
     fn test_map_matrix_from_graph() {
-        use crate::edgelist::edge_list::EdgeList;
-        use crate::edges::EdgeStructOption;
-
         // Create a source graph (edge list with nodes 10, 20, 30)
         let edges = EdgeStructOption([Some((10, 20)), Some((20, 30)), Some((10, 30)), None]);
         let source = EdgeList::<4, usize, _>::new(edges);
@@ -1200,9 +1186,6 @@ mod tests {
 
     #[test]
     fn test_map_matrix_from_graph_empty() {
-        use crate::edgelist::edge_list::EdgeList;
-        use crate::edges::EdgeStructOption;
-
         // Create an empty source graph
         let edges = EdgeStructOption([None, None, None, None]);
         let source = EdgeList::<4, usize, _>::new(edges);
@@ -1225,9 +1208,6 @@ mod tests {
 
     #[test]
     fn test_map_matrix_from_graph_capacity_exceeded() {
-        use crate::edgelist::edge_list::EdgeList;
-        use crate::edges::EdgeStructOption;
-
         // Create a source graph with 4 nodes but matrix only supports 3
         let edges = EdgeStructOption([Some((0, 1)), Some((1, 2)), Some((2, 3)), Some((3, 0))]);
         let source = EdgeList::<4, usize, _>::new(edges);
@@ -1249,9 +1229,6 @@ mod tests {
 
     #[test]
     fn test_map_matrix_from_graph_with_arbitrary_indices() {
-        use crate::edgelist::edge_list::EdgeList;
-        use crate::edges::EdgeStructOption;
-
         // Create a source graph with non-contiguous node indices
         let edges = EdgeStructOption([Some((100, 200)), Some((200, 500)), Some((500, 100)), None]);
         let source = EdgeList::<4, usize, _>::new(edges);

--- a/src/matrix/simple_matrix.rs
+++ b/src/matrix/simple_matrix.rs
@@ -237,6 +237,10 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::adjacency_list::map_adjacency_list::MapAdjacencyList;
+    use crate::containers::maps::staticdict::Dictionary;
+    use crate::containers::maps::MapTrait;
+    use crate::graph::GraphWithMutableEdges;
     use crate::tests::{collect, collect_sorted};
 
     #[test]
@@ -315,8 +319,6 @@ mod tests {
 
     #[test]
     fn test_mutable_edges_add_edge_success() {
-        use crate::graph::GraphWithMutableEdges;
-
         let mut matrix = Matrix::<3, i32, _, _>::new([
             [None, None, None],
             [None, None, None],
@@ -347,8 +349,6 @@ mod tests {
 
     #[test]
     fn test_mutable_edges_add_edge_invalid_nodes() {
-        use crate::graph::GraphWithMutableEdges;
-
         let mut matrix = Matrix::<3, i32, _, _>::new([
             [None, None, None],
             [None, None, None],
@@ -370,8 +370,6 @@ mod tests {
 
     #[test]
     fn test_mutable_edges_remove_edge_success() {
-        use crate::graph::GraphWithMutableEdges;
-
         let mut matrix = Matrix::<3, i32, _, _>::new([
             [None, Some(1), Some(2)],
             [Some(3), None, Some(4)],
@@ -403,8 +401,6 @@ mod tests {
 
     #[test]
     fn test_mutable_edges_remove_edge_not_found() {
-        use crate::graph::GraphWithMutableEdges;
-
         let mut matrix = Matrix::<3, i32, _, _>::new([
             [None, Some(1), None],
             [None, None, Some(2)],
@@ -429,8 +425,6 @@ mod tests {
 
     #[test]
     fn test_mutable_edges_add_remove_comprehensive() {
-        use crate::graph::GraphWithMutableEdges;
-
         let mut matrix = Matrix::<4, i32, _, _>::new([
             [None, None, None, None],
             [None, None, None, None],
@@ -471,8 +465,6 @@ mod tests {
 
     #[test]
     fn test_mutable_edges_overwrite_existing() {
-        use crate::graph::GraphWithMutableEdges;
-
         let mut matrix = Matrix::<3, i32, _, _>::new([
             [None, Some(42), None],
             [None, None, None],
@@ -494,8 +486,6 @@ mod tests {
 
     #[test]
     fn test_mutable_edges_self_loops() {
-        use crate::graph::GraphWithMutableEdges;
-
         let mut matrix = Matrix::<3, i32, _, _>::new([
             [None, None, None],
             [None, None, None],
@@ -523,10 +513,6 @@ mod tests {
 
     #[test]
     fn test_matrix_from_graph() {
-        use crate::adjacency_list::map_adjacency_list::MapAdjacencyList;
-        use crate::containers::maps::staticdict::Dictionary;
-        use crate::containers::maps::MapTrait;
-
         // Create a source graph (adjacency list with nodes 0, 1, 2)
         let mut dict = Dictionary::<usize, [usize; 2], 8>::new();
         dict.insert(0, [1, 2]).unwrap(); // 0 -> 1, 2
@@ -541,7 +527,10 @@ mod tests {
         // Verify edges were copied correctly
         let mut edges = [(0usize, 0usize); 16];
         let edges_slice = collect_sorted(matrix.iter_edges().unwrap(), &mut edges);
-        assert_eq!(edges_slice, &[(0, 1), (0, 2), (1, 0), (1, 2), (2, 0), (2, 1)]);
+        assert_eq!(
+            edges_slice,
+            &[(0, 1), (0, 2), (1, 0), (1, 2), (2, 0), (2, 1)]
+        );
 
         // Verify nodes are preserved
         let node_count = matrix.iter_nodes().unwrap().count();
@@ -550,9 +539,6 @@ mod tests {
 
     #[test]
     fn test_matrix_from_graph_empty() {
-        use crate::adjacency_list::map_adjacency_list::MapAdjacencyList;
-        use crate::containers::maps::staticdict::Dictionary;
-
         // Create an empty source graph
         let dict = Dictionary::<usize, [usize; 2], 8>::default();
         let source = MapAdjacencyList::new_unchecked(dict);
@@ -571,10 +557,6 @@ mod tests {
 
     #[test]
     fn test_matrix_from_graph_node_out_of_range() {
-        use crate::adjacency_list::map_adjacency_list::MapAdjacencyList;
-        use crate::containers::maps::staticdict::Dictionary;
-        use crate::containers::maps::MapTrait;
-
         // Create a source graph with node index too large for 2x2 matrix
         let mut dict = Dictionary::<usize, [usize; 2], 8>::new();
         dict.insert(0, [1, 2]).unwrap(); // Node 2 is out of range for 2x2 matrix

--- a/src/matrix/simple_matrix.rs
+++ b/src/matrix/simple_matrix.rs
@@ -540,16 +540,8 @@ mod tests {
 
         // Verify edges were copied correctly
         let mut edges = [(0usize, 0usize); 16];
-        let edges_slice = collect(matrix.iter_edges().unwrap(), &mut edges);
-        assert_eq!(edges_slice.len(), 6); // Should have 6 edges total
-
-        // Check that all expected edges are present
-        assert!(edges_slice.contains(&(0, 1)));
-        assert!(edges_slice.contains(&(0, 2)));
-        assert!(edges_slice.contains(&(1, 2)));
-        assert!(edges_slice.contains(&(1, 0)));
-        assert!(edges_slice.contains(&(2, 0)));
-        assert!(edges_slice.contains(&(2, 1)));
+        let edges_slice = collect_sorted(matrix.iter_edges().unwrap(), &mut edges);
+        assert_eq!(edges_slice, &[(0, 1), (0, 2), (1, 0), (1, 2), (2, 0), (2, 1)]);
 
         // Verify nodes are preserved
         let node_count = matrix.iter_nodes().unwrap().count();

--- a/src/matrix/simple_matrix.rs
+++ b/src/matrix/simple_matrix.rs
@@ -47,23 +47,17 @@ where
     /// * Matrix must have mutable storage (AsMut traits)
     ///
     /// # Example
-    /// ```
-    /// use heapless_graphs::matrix::simple_matrix::Matrix;
-    /// use heapless_graphs::adjacency_list::map_adjacency_list::MapAdjacencyList;
-    /// use heapless_graphs::containers::maps::staticdict::Dictionary;
-    /// use heapless_graphs::containers::maps::MapTrait;
+    /// # use heapless_graphs::matrix::simple_matrix::Matrix;
+    /// # use heapless_graphs::edgelist::edge_list::EdgeList;
+    /// # use heapless_graphs::edges::EdgeStructOption;
     ///
-    /// // Create a source graph (adjacency list)
-    /// let mut dict = Dictionary::<usize, [usize; 2], 8>::new();
-    /// dict.insert(0, [1, 2]).unwrap();
-    /// dict.insert(1, [2, 0]).unwrap();
-    /// dict.insert(2, [0, 1]).unwrap();
-    /// let source = MapAdjacencyList::new_unchecked(dict);
+    /// // Create a source graph (edge list)
+    /// let edges = EdgeStructOption([Some((0, 1)), Some((1, 2)), Some((0, 2)), None]);
+    /// let source = EdgeList::<4, usize, _>::new(edges);
     ///
     /// // Convert to Matrix (3x3 matrix to fit nodes 0, 1, 2)
-    /// let matrix: Matrix<3, (), [[Option<()>; 3]; 3], [Option<()>; 3]> =
+    /// let matrix: Matrix<3, (), [[Option<()>; 3]; 3], _> =
     ///     Matrix::from_graph(&source).unwrap();
-    /// ```
     pub fn from_graph<G>(source_graph: &G) -> Result<Self, GraphError<usize>>
     where
         G: Graph<usize>,
@@ -566,7 +560,6 @@ mod tests {
     fn test_matrix_from_graph_empty() {
         use crate::adjacency_list::map_adjacency_list::MapAdjacencyList;
         use crate::containers::maps::staticdict::Dictionary;
-        use crate::containers::maps::MapTrait;
 
         // Create an empty source graph
         let dict = Dictionary::<usize, [usize; 2], 8>::default();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced new methods to create various graph representations directly from existing graphs, enabling seamless conversion between graph types such as adjacency lists, edge lists, edge-node lists, and matrix-based graphs.
  - Added a new example demonstrating graph type conversions and usage scenarios.

- **Bug Fixes**
  - Improved error handling for capacity limits and invalid node indices during graph conversions.

- **Tests**
  - Added extensive tests to verify correctness of graph conversions, error conditions, and edge cases.

- **Documentation**
  - Enhanced documentation for new conversion methods, including usage constraints and examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->