### PR TITLE
Add from_graph trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 [package]
 name = "heapless_graphs"
 authors = ["Kaido Kert <kaidokert@gmail.com>"]
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 description = """
 Implementation of composable graphs for no_alloc environments

--- a/examples/from_graph_demo.rs
+++ b/examples/from_graph_demo.rs
@@ -8,6 +8,7 @@
 use heapless_graphs::{
     adjacency_list::map_adjacency_list::MapAdjacencyList,
     containers::maps::{staticdict::Dictionary, MapTrait},
+    conversions::FromGraph,
     edgelist::edge_list::EdgeList,
     edges::EdgeStructOption,
     graph::Graph,

--- a/src/adjacency_list/map_adjacency_list.rs
+++ b/src/adjacency_list/map_adjacency_list.rs
@@ -71,14 +71,6 @@ where
     }
 }
 
-impl<NI, E, M> MapAdjacencyList<NI, E, M>
-where
-    NI: NodeIndex,
-    E: NodesIterable<Node = NI> + MutableNodes<NI> + Default,
-    M: MapTrait<NI, E>,
-{
-}
-
 impl<NI, E, M> Graph<NI> for MapAdjacencyList<NI, E, M>
 where
     M: MapTrait<NI, E>,

--- a/src/adjacency_list/slice_adjacency_list.rs
+++ b/src/adjacency_list/slice_adjacency_list.rs
@@ -1,3 +1,4 @@
+use crate::conversions::FromGraph;
 use crate::graph::{integrity_check, Graph, GraphError, GraphWithMutableEdges, NodeIndex};
 use crate::nodes::{MutableNodes, NodesIterable};
 
@@ -128,45 +129,13 @@ where
     }
 }
 
-impl<NI, E, const N: usize> SliceAdjacencyList<NI, E, [(NI, E); N]>
+impl<NI, E, const N: usize> FromGraph<NI, GraphError<NI>>
+    for SliceAdjacencyList<NI, E, [(NI, E); N]>
 where
     NI: NodeIndex + Copy + Default,
     E: NodesIterable<Node = NI> + crate::nodes::MutableNodes<NI> + Default,
 {
-    /// Creates a SliceAdjacencyList from any graph by copying all nodes and edges
-    ///
-    /// This function works with fixed-size arrays and creates exactly N entries,
-    /// one for each node in the source graph. The source graph must have exactly
-    /// N nodes, otherwise the conversion will fail.
-    ///
-    /// # Arguments
-    /// * `source_graph` - The graph to copy nodes and edges from
-    ///
-    /// # Returns
-    /// * `Ok(SliceAdjacencyList)` if successful
-    /// * `Err(GraphError)` if node count doesn't match N or capacity is exceeded
-    ///
-    /// # Constraints
-    /// * Source graph must have exactly N nodes
-    /// * Node index type must implement Copy and Default
-    /// * Edge container E must implement Default and MutableNodes
-    /// * Requires sufficient capacity in E for all outgoing edges per node
-    ///
-    /// # Example
-    /// ```
-    /// # use heapless_graphs::adjacency_list::slice_adjacency_list::SliceAdjacencyList;
-    /// # use heapless_graphs::edgelist::edge_list::EdgeList;
-    /// # use heapless_graphs::containers::maps::MapTrait;
-    /// # use heapless_graphs::nodes::NodeStructOption;
-    ///
-    /// // Create a source graph (edge list)
-    /// let source = EdgeList::<5, _,_>::new([(0, 1), (0, 2), (1, 2), (2, 0)]);
-    ///
-    /// // Convert to SliceAdjacencyList with exactly 3 nodes and capacity for edges
-    /// let slice_graph: SliceAdjacencyList<usize, NodeStructOption<4, _>, [(_, _); 3]> =
-    ///     SliceAdjacencyList::from_graph(&source).unwrap();
-    /// ```
-    pub fn from_graph<G>(source_graph: &G) -> Result<Self, GraphError<NI>>
+    fn from_graph<G>(source_graph: &G) -> Result<Self, GraphError<NI>>
     where
         G: Graph<NI>,
         GraphError<NI>: From<G::Error>,
@@ -199,6 +168,13 @@ where
 
         Ok(Self::new_unchecked(container))
     }
+}
+
+impl<NI, E, const N: usize> SliceAdjacencyList<NI, E, [(NI, E); N]>
+where
+    NI: NodeIndex + Copy + Default,
+    E: NodesIterable<Node = NI> + crate::nodes::MutableNodes<NI> + Default,
+{
 }
 
 #[cfg(test)]

--- a/src/adjacency_list/slice_adjacency_list.rs
+++ b/src/adjacency_list/slice_adjacency_list.rs
@@ -170,13 +170,6 @@ where
     }
 }
 
-impl<NI, E, const N: usize> SliceAdjacencyList<NI, E, [(NI, E); N]>
-where
-    NI: NodeIndex + Copy + Default,
-    E: NodesIterable<Node = NI> + crate::nodes::MutableNodes<NI> + Default,
-{
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/algorithms/traversal.rs
+++ b/src/algorithms/traversal.rs
@@ -648,8 +648,6 @@ mod tests {
 
     #[test]
     fn test_bfs_unchecked() {
-        use crate::containers::queues::CircularQueue;
-
         let graph = EdgeList::<8, _, _>::new([(0usize, 1usize), (0, 2), (1, 3), (2, 3)]);
         let mut visited = [false; 16];
         let mut collector = Collector::<usize, 16>::new();
@@ -666,8 +664,6 @@ mod tests {
 
     #[test]
     fn test_dfs_iterative_unchecked() {
-        use crate::containers::queues::CircularQueue;
-
         let graph = EdgeList::<8, _, _>::new([(0usize, 1usize), (0, 2), (1, 3), (2, 3)]);
         let mut visited = [false; 16];
         let mut collector = Collector::<usize, 16>::new();
@@ -684,8 +680,6 @@ mod tests {
 
     #[test]
     fn test_bfs_with_owned_and_borrowed_graphs() {
-        use crate::containers::queues::CircularQueue;
-
         let graph = EdgeList::<8, _, _>::new([(0usize, 1usize), (0, 2), (1, 3)]);
 
         // Test with borrowed graph (&graph)
@@ -717,8 +711,6 @@ mod tests {
 
     #[test]
     fn test_dfs_iterative_with_owned_and_borrowed_graphs() {
-        use crate::containers::queues::CircularQueue;
-
         let graph = EdgeList::<8, _, _>::new([(0usize, 1usize), (0, 2), (1, 3)]);
 
         // Test with borrowed graph (&graph)

--- a/src/conversions.rs
+++ b/src/conversions.rs
@@ -33,7 +33,7 @@ use crate::graph::{Graph, NodeIndex};
 /// use heapless_graphs::matrix::simple_matrix::Matrix;
 /// use heapless_graphs::adjacency_list::map_adjacency_list::MapAdjacencyList;
 /// // ... (setup source graph)
-/// // let target_matrix = Matrix::from_graph2(&source_graph)?;
+/// // let target_matrix = Matrix::from_graph(&source_graph)?;
 /// ```
 pub trait FromGraph<NI, E>
 where

--- a/src/conversions.rs
+++ b/src/conversions.rs
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Graph conversion traits and utilities
+//!
+//! This module provides traits and functions for converting between different graph representations.
+
+use crate::graph::{Graph, NodeIndex};
+
+/// Trait for graph types that can be constructed from other graph types
+///
+/// This trait provides a standardized way to convert from any source graph
+/// to the implementing graph type. It handles the common pattern of copying
+/// nodes and edges from a source graph while managing capacity constraints
+/// and error handling.
+///
+/// # Type Parameters
+/// * `NI` - The node index type for the target graph
+/// * `E` - The error type returned by the conversion
+///
+/// # Implementation Guidelines
+///
+/// Implementations should:
+/// 1. Iterate over all nodes in the source graph and copy them
+/// 2. Iterate over all edges in the source graph and copy them
+/// 3. Handle capacity constraints appropriately for the target graph type
+/// 4. Convert source graph errors to the target error type
+/// 5. Support empty graphs (graphs with no nodes/edges)
+///
+/// # Examples
+///
+/// ```
+/// use heapless_graphs::conversions::FromGraph;
+/// use heapless_graphs::matrix::simple_matrix::Matrix;
+/// use heapless_graphs::adjacency_list::map_adjacency_list::MapAdjacencyList;
+/// // ... (setup source graph)
+/// // let target_matrix = Matrix::from_graph2(&source_graph)?;
+/// ```
+pub trait FromGraph<NI, E>
+where
+    NI: NodeIndex,
+{
+    /// Creates a new graph by copying data from the source graph
+    ///
+    /// This function converts any graph that implements the `Graph` trait
+    /// into the target graph type. The conversion process typically involves:
+    ///
+    /// 1. **Node collection**: Gathering all nodes from the source graph
+    /// 2. **Edge collection**: Gathering all edges from the source graph
+    /// 3. **Capacity validation**: Ensuring the target graph can hold all data
+    /// 4. **Data population**: Creating the target graph with the copied data
+    ///
+    /// # Arguments
+    /// * `source_graph` - The graph to convert from
+    ///
+    /// # Returns
+    /// * `Ok(Self)` - Successfully created target graph
+    /// * `Err(E)` - Conversion failed (capacity, invalid data, etc.)
+    ///
+    /// # Errors
+    ///
+    /// Common error conditions include:
+    /// * **Capacity exceeded**: Target graph cannot hold all nodes/edges
+    /// * **Invalid node indices**: Source nodes outside target's valid range
+    /// * **Source iteration failure**: Problems reading from source graph
+    /// * **Memory allocation**: Target graph construction failed
+    fn from_graph<G>(source_graph: &G) -> Result<Self, E>
+    where
+        G: Graph<NI>,
+        E: From<G::Error>,
+        Self: Sized;
+}

--- a/src/edgelist/edge_list.rs
+++ b/src/edgelist/edge_list.rs
@@ -87,13 +87,6 @@ where
     }
 }
 
-impl<const N: usize, NI, E> EdgeList<N, NI, E>
-where
-    NI: NodeIndex + Ord + PartialEq,
-    E: crate::edges::EdgesIterable<Node = NI> + crate::edges::MutableEdges<NI> + Default,
-{
-}
-
 impl<const N: usize, NI, E> Graph<NI> for EdgeList<N, NI, E>
 where
     E: crate::edges::EdgesIterable<Node = NI>,

--- a/src/edgelist/edge_list.rs
+++ b/src/edgelist/edge_list.rs
@@ -1,5 +1,5 @@
+use crate::conversions::FromGraph;
 use crate::edges::EdgeNodeError;
-
 use crate::graph::{Graph, GraphError, GraphWithMutableEdges, NodeIndex};
 
 #[derive(Debug)]
@@ -61,44 +61,14 @@ impl<const N: usize, NI, E> EdgeList<N, NI, E> {
     }
 }
 
-impl<const N: usize, NI, E> EdgeList<N, NI, E>
+impl<const N: usize, NI, E> FromGraph<NI, EdgeListError<NI>> for EdgeList<N, NI, E>
 where
     NI: NodeIndex + Ord + PartialEq,
     E: crate::edges::EdgesIterable<Node = NI> + crate::edges::MutableEdges<NI> + Default,
 {
-    /// Creates an EdgeList from any graph by copying all edges
-    ///
-    /// This function iterates over all edges in the source graph and adds them
-    /// to a new EdgeList. The edge container must support mutation and have
-    /// default initialization.
-    ///
-    /// # Arguments
-    /// * `source_graph` - The graph to copy edges from
-    ///
-    /// # Returns
-    /// * `Ok(EdgeList)` if successful
-    /// * `Err(G::Error)` if iteration over the source graph fails
-    ///
-    /// # Example
-    /// ```
-    /// use heapless_graphs::edgelist::edge_list::EdgeList;
-    /// use heapless_graphs::edges::EdgeStructOption;
-    /// use heapless_graphs::adjacency_list::map_adjacency_list::MapAdjacencyList;
-    /// use heapless_graphs::containers::maps::staticdict::Dictionary;
-    /// use heapless_graphs::containers::maps::MapTrait;
-    ///
-    /// // Create a source graph (adjacency list)
-    /// let mut dict = Dictionary::<usize, [usize; 2], 8>::new();
-    /// dict.insert(0, [1, 2]).unwrap();
-    /// dict.insert(1, [2, 0]).unwrap();
-    /// let source = MapAdjacencyList::new_unchecked(dict);
-    ///
-    /// // Convert to EdgeList
-    /// let edge_list: EdgeList<8, usize, EdgeStructOption<16, _>> =
-    ///     EdgeList::from_graph(&source).unwrap();
-    /// ```
-    pub fn from_graph<G: Graph<NI>>(source_graph: &G) -> Result<Self, EdgeListError<NI>>
+    fn from_graph<G>(source_graph: &G) -> Result<Self, EdgeListError<NI>>
     where
+        G: Graph<NI>,
         EdgeListError<NI>: From<G::Error>,
     {
         let mut edges = E::default();
@@ -115,6 +85,13 @@ where
             _phantom: Default::default(),
         })
     }
+}
+
+impl<const N: usize, NI, E> EdgeList<N, NI, E>
+where
+    NI: NodeIndex + Ord + PartialEq,
+    E: crate::edges::EdgesIterable<Node = NI> + crate::edges::MutableEdges<NI> + Default,
+{
 }
 
 impl<const N: usize, NI, E> Graph<NI> for EdgeList<N, NI, E>
@@ -603,5 +580,23 @@ mod tests {
         let mut edges = [(0usize, 0usize); 16];
         let edges_slice = collect(edge_list.iter_edges().unwrap(), &mut edges);
         assert_eq!(edges_slice.len(), 0);
+    }
+
+    #[test]
+    fn test_edge_list_from_graph_trait() {
+        // Create a source graph (adjacency list)
+        let mut dict = Dictionary::<usize, [usize; 2], 8>::new();
+        dict.insert(0, [1, 2]).unwrap(); // 0 -> 1, 2
+        dict.insert(1, [2, 0]).unwrap(); // 1 -> 2, 0
+        let source = MapAdjacencyList::new_unchecked(dict);
+
+        // Use the trait method instead of the direct method
+        let edge_list: EdgeList<8, usize, EdgeStructOption<16, usize>> =
+            EdgeList::from_graph(&source).unwrap();
+
+        // Verify it works the same as from_graph
+        let mut edges = [(0usize, 0usize); 16];
+        let edges_slice = collect(edge_list.iter_edges().unwrap(), &mut edges);
+        assert_eq!(edges_slice, &[(0, 1), (0, 2), (1, 2), (1, 0)]);
     }
 }

--- a/src/edgelist/edge_node_list.rs
+++ b/src/edgelist/edge_node_list.rs
@@ -80,14 +80,6 @@ where
     }
 }
 
-impl<NI, E, N> EdgeNodeList<NI, E, N>
-where
-    NI: NodeIndex + Copy + Default,
-    E: crate::edges::EdgesIterable<Node = NI> + crate::edges::MutableEdges<NI> + Default,
-    N: crate::nodes::NodesIterable<Node = NI> + crate::nodes::MutableNodes<NI> + Default,
-{
-}
-
 impl<NI, E, N> Graph<NI> for EdgeNodeList<NI, E, N>
 where
     NI: NodeIndex,

--- a/src/edgelist/edge_node_list.rs
+++ b/src/edgelist/edge_node_list.rs
@@ -1,3 +1,4 @@
+use crate::conversions::FromGraph;
 use crate::graph::{integrity_check, Graph, GraphError, GraphWithMutableNodes, NodeIndex};
 use crate::nodes::MutableNodes;
 
@@ -46,44 +47,13 @@ impl<NI, E, N> EdgeNodeList<NI, E, N> {
     }
 }
 
-impl<NI, E, N> EdgeNodeList<NI, E, N>
+impl<NI, E, N> FromGraph<NI, GraphError<NI>> for EdgeNodeList<NI, E, N>
 where
     NI: NodeIndex + Copy + Default,
     E: crate::edges::EdgesIterable<Node = NI> + crate::edges::MutableEdges<NI> + Default,
     N: crate::nodes::NodesIterable<Node = NI> + crate::nodes::MutableNodes<NI> + Default,
 {
-    /// Creates an EdgeNodeList from any graph by copying all nodes and edges
-    ///
-    /// This function iterates over all nodes and edges in the source graph and creates
-    /// an EdgeNodeList representation. Both nodes and edges are stored explicitly.
-    ///
-    /// # Arguments
-    /// * `source_graph` - The graph to copy nodes and edges from
-    ///
-    /// # Returns
-    /// * `Ok(EdgeNodeList)` if successful
-    /// * `Err(GraphError)` if iteration fails or capacity is exceeded
-    ///
-    /// # Constraints
-    /// * Node index type must implement Copy
-    /// * Edge container E must implement Default and MutableEdges
-    /// * Node container N must implement Default and MutableNodes
-    /// * Requires sufficient capacity in both E and N for all edges and nodes
-    ///
-    /// # Example
-    /// # use heapless_graphs::edgelist::edge_node_list::EdgeNodeList;
-    /// # use heapless_graphs::edgelist::edge_list::EdgeList;
-    /// # use heapless_graphs::edges::EdgeStructOption;
-    /// # use heapless_graphs::nodes::NodeStructOption;
-    ///
-    /// // Create a source graph (edge list)
-    /// let edges = EdgeStructOption([Some((0, 1)), Some((1, 2)), Some((0, 2)), None]);
-    /// let source = EdgeList::<4, usize, _>::new(edges);
-    ///
-    /// // Convert to EdgeNodeList with capacity for nodes and edges
-    /// let edge_node_graph: EdgeNodeList<usize, EdgeStructOption<8, _>, NodeStructOption<4, _>> =
-    ///     EdgeNodeList::from_graph(&source).unwrap();
-    pub fn from_graph<G>(source_graph: &G) -> Result<Self, GraphError<NI>>
+    fn from_graph<G>(source_graph: &G) -> Result<Self, GraphError<NI>>
     where
         G: Graph<NI>,
         GraphError<NI>: From<G::Error>,
@@ -108,6 +78,14 @@ where
 
         Ok(Self::new_unchecked(edges, nodes))
     }
+}
+
+impl<NI, E, N> EdgeNodeList<NI, E, N>
+where
+    NI: NodeIndex + Copy + Default,
+    E: crate::edges::EdgesIterable<Node = NI> + crate::edges::MutableEdges<NI> + Default,
+    N: crate::nodes::NodesIterable<Node = NI> + crate::nodes::MutableNodes<NI> + Default,
+{
 }
 
 impl<NI, E, N> Graph<NI> for EdgeNodeList<NI, E, N>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,6 +74,7 @@
 pub mod adjacency_list;
 pub mod algorithms;
 pub mod containers;
+pub mod conversions;
 pub mod edgelist;
 pub mod edges;
 pub mod graph;

--- a/src/matrix/bit_map_matrix.rs
+++ b/src/matrix/bit_map_matrix.rs
@@ -1,5 +1,6 @@
 use crate::{
     containers::maps::MapTrait,
+    conversions::FromGraph,
     graph::{Graph, GraphError, GraphWithMutableEdges, GraphWithMutableNodes, NodeIndex},
 };
 
@@ -55,44 +56,13 @@ where
     }
 }
 
-impl<const N: usize, const R: usize, NI, M> BitMapMatrix<N, R, NI, M>
+impl<const N: usize, const R: usize, NI, M> FromGraph<NI, GraphError<NI>>
+    for BitMapMatrix<N, R, NI, M>
 where
     NI: NodeIndex + Copy,
     M: MapTrait<NI, usize> + Default,
 {
-    /// Creates a BitMapMatrix from any graph by copying all nodes and edges
-    ///
-    /// This function creates a mapping from arbitrary node indices to bit matrix positions (0..8*N)
-    /// and populates the underlying bit matrix with edges. Each node in the source graph is
-    /// assigned a unique matrix index from 0 to 8*N-1.
-    ///
-    /// # Arguments
-    /// * `source_graph` - The graph to copy nodes and edges from
-    ///
-    /// # Returns
-    /// * `Ok(BitMapMatrix)` if successful
-    /// * `Err(GraphError)` if too many nodes or iteration fails
-    ///
-    /// # Constraints
-    /// * Source graph must have at most 8*N nodes (BitMatrix capacity)
-    /// * Node index type must implement Copy
-    /// * Requires R = 8*N for valid BitMatrix dimensions
-    /// * Map M must have sufficient capacity for all nodes
-    ///
-    /// # Example
-    /// # use heapless_graphs::matrix::bit_map_matrix::BitMapMatrix;
-    /// # use heapless_graphs::edgelist::edge_list::EdgeList;
-    /// # use heapless_graphs::edges::EdgeStructOption;
-    /// # use heapless_graphs::containers::maps::staticdict::Dictionary;
-    ///
-    /// // Create a source graph (edge list)
-    /// let edges = EdgeStructOption([Some((0, 1)), Some((1, 2)), Some((0, 2)), None]);
-    /// let source = EdgeList::<4, usize, _>::new(edges);
-    ///
-    /// // Convert to BitMapMatrix (8 nodes capacity)
-    /// let bit_map_matrix: BitMapMatrix<1, 8, usize, Dictionary<_, _, 8>> =
-    ///     BitMapMatrix::from_graph(&source).unwrap();
-    pub fn from_graph<G>(source_graph: &G) -> Result<Self, GraphError<NI>>
+    fn from_graph<G>(source_graph: &G) -> Result<Self, GraphError<NI>>
     where
         G: Graph<NI>,
         GraphError<NI>: From<G::Error>,
@@ -155,6 +125,13 @@ where
 
         Ok(Self::new_unchecked(bitmap, index_map))
     }
+}
+
+impl<const N: usize, const R: usize, NI, M> BitMapMatrix<N, R, NI, M>
+where
+    NI: NodeIndex + Copy,
+    M: MapTrait<NI, usize> + Default,
+{
 }
 
 impl<const N: usize, const R: usize, NI, M> Graph<NI> for BitMapMatrix<N, R, NI, M>

--- a/src/matrix/bit_map_matrix.rs
+++ b/src/matrix/bit_map_matrix.rs
@@ -127,13 +127,6 @@ where
     }
 }
 
-impl<const N: usize, const R: usize, NI, M> BitMapMatrix<N, R, NI, M>
-where
-    NI: NodeIndex + Copy,
-    M: MapTrait<NI, usize> + Default,
-{
-}
-
 impl<const N: usize, const R: usize, NI, M> Graph<NI> for BitMapMatrix<N, R, NI, M>
 where
     NI: NodeIndex,

--- a/src/matrix/map_matrix.rs
+++ b/src/matrix/map_matrix.rs
@@ -1,5 +1,6 @@
 use crate::{
     containers::maps::MapTrait,
+    conversions::FromGraph,
     graph::{Graph, GraphError, GraphWithMutableEdges, GraphWithMutableNodes, NodeIndex},
 };
 
@@ -53,7 +54,8 @@ where
     }
 }
 
-impl<const N: usize, NI, EDGEVALUE, M, COLUMNS, ROW> MapMatrix<N, NI, EDGEVALUE, M, COLUMNS, ROW>
+impl<const N: usize, NI, EDGEVALUE, M, COLUMNS, ROW> FromGraph<NI, GraphError<NI>>
+    for MapMatrix<N, NI, EDGEVALUE, M, COLUMNS, ROW>
 where
     NI: NodeIndex + Copy,
     EDGEVALUE: Default,
@@ -61,39 +63,7 @@ where
     COLUMNS: AsRef<[ROW]> + AsMut<[ROW]> + Default,
     M: MapTrait<NI, usize> + Default,
 {
-    /// Creates a MapMatrix from any graph by copying all nodes and edges
-    ///
-    /// This function creates a mapping from arbitrary node indices to matrix positions (0..N)
-    /// and populates the underlying matrix with edges. Each node in the source graph is
-    /// assigned a unique matrix index from 0 to N-1.
-    ///
-    /// # Arguments
-    /// * `source_graph` - The graph to copy nodes and edges from
-    ///
-    /// # Returns
-    /// * `Ok(MapMatrix)` if successful
-    /// * `Err(GraphError)` if too many nodes or iteration fails
-    ///
-    /// # Constraints
-    /// * Source graph must have at most N nodes
-    /// * Node index type must implement Copy
-    /// * Edge values use EDGEVALUE::default() for all edges
-    /// * Map M must have sufficient capacity for all nodes
-    ///
-    /// # Example
-    /// # use heapless_graphs::matrix::map_matrix::MapMatrix;
-    /// # use heapless_graphs::edgelist::edge_list::EdgeList;
-    /// # use heapless_graphs::edges::EdgeStructOption;
-    /// # use heapless_graphs::containers::maps::staticdict::Dictionary;
-    ///
-    /// // Create a source graph (edge list)
-    /// let edges = EdgeStructOption([Some((0, 1)), Some((1, 2)), Some((0, 2)), None]);
-    /// let source = EdgeList::<4, usize, _>::new(edges);
-    ///
-    /// // Convert to MapMatrix (3x3 matrix to fit nodes 0, 1, 2)
-    /// let map_matrix: MapMatrix<3, usize, (), Dictionary<_, _, 8>, [[Option<()>; 3]; 3], _> =
-    ///     MapMatrix::from_graph(&source).unwrap();
-    pub fn from_graph<G>(source_graph: &G) -> Result<Self, GraphError<NI>>
+    fn from_graph<G>(source_graph: &G) -> Result<Self, GraphError<NI>>
     where
         G: Graph<NI>,
         GraphError<NI>: From<G::Error>,
@@ -157,6 +127,16 @@ where
             _phantom: Default::default(),
         })
     }
+}
+
+impl<const N: usize, NI, EDGEVALUE, M, COLUMNS, ROW> MapMatrix<N, NI, EDGEVALUE, M, COLUMNS, ROW>
+where
+    NI: NodeIndex + Copy,
+    EDGEVALUE: Default,
+    ROW: AsRef<[Option<EDGEVALUE>]> + AsMut<[Option<EDGEVALUE>]>,
+    COLUMNS: AsRef<[ROW]> + AsMut<[ROW]> + Default,
+    M: MapTrait<NI, usize> + Default,
+{
 }
 
 impl<const N: usize, NI, EDGEVALUE, M, COLUMNS, ROW> Graph<NI>

--- a/src/matrix/map_matrix.rs
+++ b/src/matrix/map_matrix.rs
@@ -129,15 +129,6 @@ where
     }
 }
 
-impl<const N: usize, NI, EDGEVALUE, M, COLUMNS, ROW> MapMatrix<N, NI, EDGEVALUE, M, COLUMNS, ROW>
-where
-    NI: NodeIndex + Copy,
-    EDGEVALUE: Default,
-    ROW: AsRef<[Option<EDGEVALUE>]> + AsMut<[Option<EDGEVALUE>]>,
-    COLUMNS: AsRef<[ROW]> + AsMut<[ROW]> + Default,
-    M: MapTrait<NI, usize> + Default,
-{
-}
 
 impl<const N: usize, NI, EDGEVALUE, M, COLUMNS, ROW> Graph<NI>
     for MapMatrix<N, NI, EDGEVALUE, M, COLUMNS, ROW>

--- a/src/matrix/map_matrix.rs
+++ b/src/matrix/map_matrix.rs
@@ -129,7 +129,6 @@ where
     }
 }
 
-
 impl<const N: usize, NI, EDGEVALUE, M, COLUMNS, ROW> Graph<NI>
     for MapMatrix<N, NI, EDGEVALUE, M, COLUMNS, ROW>
 where

--- a/src/matrix/simple_matrix.rs
+++ b/src/matrix/simple_matrix.rs
@@ -23,14 +23,6 @@ where
     }
 }
 
-impl<const N: usize, EDGEVALUE, ROW, COLUMNS> Matrix<N, EDGEVALUE, COLUMNS, ROW>
-where
-    EDGEVALUE: Default,
-    ROW: AsRef<[Option<EDGEVALUE>]> + AsMut<[Option<EDGEVALUE>]>,
-    COLUMNS: AsRef<[ROW]> + AsMut<[ROW]> + Default,
-{
-}
-
 impl<const N: usize, EDGEVALUE, COLUMNS, ROW> FromGraph<usize, GraphError<usize>>
     for Matrix<N, EDGEVALUE, COLUMNS, ROW>
 where

--- a/src/matrix/simple_matrix.rs
+++ b/src/matrix/simple_matrix.rs
@@ -1,3 +1,4 @@
+use crate::conversions::FromGraph;
 use crate::graph::{Graph, GraphError, GraphWithMutableEdges};
 
 pub struct Matrix<const N: usize, EDGEVALUE, COLUMNS, ROW>
@@ -28,37 +29,16 @@ where
     ROW: AsRef<[Option<EDGEVALUE>]> + AsMut<[Option<EDGEVALUE>]>,
     COLUMNS: AsRef<[ROW]> + AsMut<[ROW]> + Default,
 {
-    /// Creates a Matrix from any graph by copying all edges
-    ///
-    /// This function iterates over all edges in the source graph and adds them
-    /// to a new Matrix. The source graph must have usize node indices in the
-    /// range 0..N, where N is the matrix size.
-    ///
-    /// # Arguments
-    /// * `source_graph` - The graph to copy edges from
-    ///
-    /// # Returns
-    /// * `Ok(Matrix)` if successful
-    /// * `Err(GraphError)` if any node indices are out of range or iteration fails
-    ///
-    /// # Constraints
-    /// * Source graph nodes must be usize indices from 0 to N-1
-    /// * Edge values use EDGEVALUE::default() for all edges
-    /// * Matrix must have mutable storage (AsMut traits)
-    ///
-    /// # Example
-    /// # use heapless_graphs::matrix::simple_matrix::Matrix;
-    /// # use heapless_graphs::edgelist::edge_list::EdgeList;
-    /// # use heapless_graphs::edges::EdgeStructOption;
-    ///
-    /// // Create a source graph (edge list)
-    /// let edges = EdgeStructOption([Some((0, 1)), Some((1, 2)), Some((0, 2)), None]);
-    /// let source = EdgeList::<4, usize, _>::new(edges);
-    ///
-    /// // Convert to Matrix (3x3 matrix to fit nodes 0, 1, 2)
-    /// let matrix: Matrix<3, (), [[Option<()>; 3]; 3], _> =
-    ///     Matrix::from_graph(&source).unwrap();
-    pub fn from_graph<G>(source_graph: &G) -> Result<Self, GraphError<usize>>
+}
+
+impl<const N: usize, EDGEVALUE, COLUMNS, ROW> FromGraph<usize, GraphError<usize>>
+    for Matrix<N, EDGEVALUE, COLUMNS, ROW>
+where
+    EDGEVALUE: Default,
+    ROW: AsRef<[Option<EDGEVALUE>]> + AsMut<[Option<EDGEVALUE>]>,
+    COLUMNS: AsRef<[ROW]> + AsMut<[ROW]> + Default,
+{
+    fn from_graph<G>(source_graph: &G) -> Result<Self, GraphError<usize>>
     where
         G: Graph<usize>,
         GraphError<usize>: From<G::Error>,
@@ -568,5 +548,27 @@ mod tests {
 
         // Should fail because node 2 is out of range
         assert!(matches!(result, Err(GraphError::EdgeHasInvalidNode(2))));
+    }
+
+    #[test]
+    fn test_matrix_from_graph_trait() {
+        // Create a source graph (adjacency list with nodes 0, 1, 2)
+        let mut dict = Dictionary::<usize, [usize; 2], 8>::new();
+        dict.insert(0, [1, 2]).unwrap(); // 0 -> 1, 2
+        dict.insert(1, [2, 0]).unwrap(); // 1 -> 2, 0
+        dict.insert(2, [0, 1]).unwrap(); // 2 -> 0, 1
+        let source = MapAdjacencyList::new_unchecked(dict);
+
+        // Use the trait method instead of the direct method
+        let matrix: Matrix<4, (), [[Option<()>; 4]; 4], [Option<()>; 4]> =
+            Matrix::from_graph(&source).unwrap();
+
+        // Verify it works the same as from_graph
+        let mut edges = [(0usize, 0usize); 16];
+        let edges_slice = collect_sorted(matrix.iter_edges().unwrap(), &mut edges);
+        assert_eq!(
+            edges_slice,
+            &[(0, 1), (0, 2), (1, 0), (1, 2), (2, 0), (2, 1)]
+        );
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a unified trait for converting between different graph representations, enabling flexible and standardized graph conversions across the library.

- **Refactor**
  - Migrated all graph conversion methods to use the new trait-based approach, replacing previous standalone methods with trait implementations for various graph types.
  - Added new tests to verify the trait-based graph conversion implementations.

- **Bug Fixes**
  - Improved error handling and consistency during graph conversions, ensuring capacity and index checks are uniformly applied.

- **Chores**
  - Cleaned up test code by removing redundant imports and updating tests to verify trait-based conversions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->