### PR TITLE
Restrict workflow push branches

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,6 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+      - dev
+      - 'feature/*'
+  pull_request:
 
 name: Build and test
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -3,7 +3,9 @@ name: Coverage
 on:
   push:
     branches:
-      - '*'
+      - main
+      - dev
+      - 'feature/*'
   pull_request:
     branches:
       - '*'

--- a/.github/workflows/cross.yaml
+++ b/.github/workflows/cross.yaml
@@ -1,6 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+      - dev
+      - 'feature/*'
+  pull_request:
 
 name: Cross-compile
 

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -5,7 +5,10 @@ name: Pre-commit
 on:
   pull_request:
   push:
-    branches: [main]
+    branches:
+      - main
+      - dev
+      - 'feature/*'
 
 jobs:
   pre-commit:


### PR DESCRIPTION
## Summary
- limit push triggers for all workflows to `main`, `dev`, and `feature/*`
- fix line endings in coverage workflow

## Testing
- `cargo test --quiet`
- `pre-commit run --files .github/workflows/coverage.yml .github/workflows/pre-commit.yaml .github/workflows/build.yaml .github/workflows/cross.yaml`

------
https://chatgpt.com/codex/tasks/task_e_687df86b6da08331a38ceda0e84438ca

## Summary by Sourcery

Restrict workflow push triggers to main, dev, and feature/* branches and fix line endings in the coverage workflow

CI:
- Limit push events to main, dev, and feature/* branches for all workflows
- Fix line endings in the coverage workflow