### PR TITLE
Handle zero capacity in hash tables

### DIFF
--- a/src/containers/maps/staticdict.rs
+++ b/src/containers/maps/staticdict.rs
@@ -119,6 +119,9 @@ where
     }
 
     fn insert(&mut self, key: K, value: V) -> Result<Option<V>, (K, V)> {
+        if N == 0 {
+            return Err((key, value));
+        }
         let (exists, index) = self.find_key_with_hash(&key);
         if !exists {
             // Check if the target slot is available for insertion
@@ -470,5 +473,13 @@ mod collision_behavior_tests {
         assert!(dict.contains_key(&1));
         assert!(dict.contains_key(&2));
         assert!(!dict.contains_key(&3));
+    }
+
+    #[test]
+    fn test_zero_capacity_insert() {
+        let mut dict: Dictionary<i32, i32, 0> = Dictionary::new();
+        assert!(dict.is_empty());
+        assert_eq!(dict.insert(1, 1), Err((1, 1)));
+        assert!(dict.is_empty());
     }
 }

--- a/src/containers/probing.rs
+++ b/src/containers/probing.rs
@@ -22,6 +22,9 @@ pub trait ProbableSlot<K> {
 
 /// Computes the hash for a key and returns the initial index
 pub fn hash_key<K: Hash, const N: usize>(key: &K) -> usize {
+    if N == 0 {
+        return 0;
+    }
     let mut hasher = Djb2Hasher::default();
     key.hash(&mut hasher);
     (hasher.finish() as usize) % N

--- a/src/containers/sets/staticset.rs
+++ b/src/containers/sets/staticset.rs
@@ -67,6 +67,9 @@ impl<K: Eq + Hash, const N: usize> SetTrait<K> for Set<K, N> {
     }
 
     fn insert(&mut self, key: K) -> Result<bool, K> {
+        if N == 0 {
+            return Err(key);
+        }
         let (exists, index) = self.find_key_with_hash(&key);
         if !exists {
             // Check if the target slot is available for insertion
@@ -327,5 +330,13 @@ mod collision_behavior_tests {
         assert!(!set.contains(&4)); // Removed
         assert!(set.contains(&8));
         assert!(set.contains(&12));
+    }
+
+    #[test]
+    fn test_zero_capacity_insert() {
+        let mut set: Set<i32, 0> = Set::new();
+        assert!(set.is_empty());
+        assert_eq!(set.insert(1), Err(1));
+        assert!(set.is_empty());
     }
 }


### PR DESCRIPTION
## Summary
- avoid modulo by zero in `hash_key`
- return errors when inserting into zero sized `Set` or `Dictionary`
- add regression tests for these cases

## Testing
- `cargo fmt --all`
- `cargo check --quiet`
- `cargo clippy --quiet -- -D warnings`
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_687e686e60488331b7c0a20cf4d2e8db