### PR TITLE
Add mutable node value trait

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -62,7 +62,11 @@ The library provides two complementary traits for dynamic node operations:
 
 Some flexible containers (e.g., `NodeValueStructOption`) implement both traits through dual implementations, allowing them to be used in either context.
 
-**TODO**: Implement graph-level traits (e.g., `GraphWithMutableNodeValues`) that leverage `MutableNodeValue` for adding/removing nodes with values at the graph level, complementing the existing `GraphWithMutableNodes` trait.
+In addition to container-level operations, the library offers the
+`GraphWithMutableNodeValues` trait for graph structures. This trait uses the
+`MutableNodeValue` operations of the underlying node container to add and remove
+nodes together with their values, providing the same integrity guarantees as
+`GraphWithMutableNodes`.
 
 ### Graph Implementations
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -66,7 +66,9 @@ In addition to container-level operations, the library offers the
 `GraphWithMutableNodeValues` trait for graph structures. This trait uses the
 `MutableNodeValue` operations of the underlying node container to add and remove
 nodes together with their values, providing the same integrity guarantees as
-`GraphWithMutableNodes`.
+`GraphWithMutableNodes`. Removing a node via this trait also cleans up all
+outgoing edges from that node. Currently only `EdgeNodeList` stores node values
+and therefore implements this trait.
 
 ### Graph Implementations
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -66,9 +66,9 @@ In addition to container-level operations, the library offers the
 `GraphWithMutableNodeValues` trait for graph structures. This trait uses the
 `MutableNodeValue` operations of the underlying node container to add and remove
 nodes together with their values, providing the same integrity guarantees as
-`GraphWithMutableNodes`. Removing a node via this trait also cleans up all
-outgoing edges from that node. Currently only `EdgeNodeList` stores node values
-and therefore implements this trait.
+`GraphWithMutableNodes`. A node cannot be removed through this trait if it still
+has incoming **or outgoing** edges. Currently only `EdgeNodeList` stores node
+values and therefore implements this trait.
 
 ### Graph Implementations
 

--- a/README.md
+++ b/README.md
@@ -17,14 +17,6 @@ microcontrollers.
 Three types of graphs are implemented: adjacency lists, edge lists, and adjacency matrices, all
 implementing the same shared trait for a graph.
 
-Graphs storing values for nodes expose them through `GraphWithNodeValues`. When
-mutability is required, the `GraphWithMutableNodeValues` trait allows adding or
-removing nodes together with their values while performing the same integrity
-checks as normal node insertion/removal. A node cannot be removed via this
-trait if it still has incoming or outgoing edges. At the moment this capability
-is available on `EdgeNodeList` only, as adjacency-list and matrix graphs do not
-store node values.
-
 Code example with a simple graph:
 ```Rust
    // Make a graph from edges and nodes

--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ microcontrollers.
 Three types of graphs are implemented: adjacency lists, edge lists, and adjacency matrices, all
 implementing the same shared trait for a graph.
 
+Graphs storing values for nodes expose them through `GraphWithNodeValues`. When
+mutability is required, the `GraphWithMutableNodeValues` trait allows adding or
+removing nodes together with their values while performing the same integrity
+checks as normal node insertion/removal.
+
 Code example with a simple graph:
 ```Rust
    // Make a graph from edges and nodes

--- a/README.md
+++ b/README.md
@@ -20,8 +20,9 @@ implementing the same shared trait for a graph.
 Graphs storing values for nodes expose them through `GraphWithNodeValues`. When
 mutability is required, the `GraphWithMutableNodeValues` trait allows adding or
 removing nodes together with their values while performing the same integrity
-checks as normal node insertion/removal. At the moment this capability is
-available on `EdgeNodeList` only, as adjacency-list and matrix graphs do not
+checks as normal node insertion/removal. A node cannot be removed via this
+trait if it still has incoming or outgoing edges. At the moment this capability
+is available on `EdgeNodeList` only, as adjacency-list and matrix graphs do not
 store node values.
 
 Code example with a simple graph:

--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ implementing the same shared trait for a graph.
 Graphs storing values for nodes expose them through `GraphWithNodeValues`. When
 mutability is required, the `GraphWithMutableNodeValues` trait allows adding or
 removing nodes together with their values while performing the same integrity
-checks as normal node insertion/removal.
+checks as normal node insertion/removal. At the moment this capability is
+available on `EdgeNodeList` only, as adjacency-list and matrix graphs do not
+store node values.
 
 Code example with a simple graph:
 ```Rust

--- a/TODO.md
+++ b/TODO.md
@@ -56,7 +56,7 @@ Graph Properties:
 Graph Manipulation:
 - [x] Node Removal: Removes a specific node and its associated edges from the graph. (implemented but lightly tested)
 - [x] Node Addition: Adds a new node to the graph. (implemented but lightly tested)
-- [ ] Node Addition with Values: Implement GraphWithMutableNodeValues trait that uses MutableNodeValue for adding nodes with associated values
+- [x] Node Addition with Values: Implement GraphWithMutableNodeValues trait that uses MutableNodeValue for adding nodes with associated values
 - [x] Edge Addition: Adds a new edge to the graph. (implemented but lightly tested)
 - [x] Edge Removal: Removes a specific edge from the graph - how to refer to it when we have duplicates ?
 - [x] Transposing a graph

--- a/src/edgelist/edge_node_list.rs
+++ b/src/edgelist/edge_node_list.rs
@@ -198,7 +198,7 @@ where
             return Err(GraphError::NodeHasIncomingEdges(node));
         }
         if self.outgoing_edges(node)?.next().is_some() {
-            return Err(GraphError::NodeHasIncomingEdges(node));
+            return Err(GraphError::NodeHasOutgoingEdges(node));
         }
 
         self.nodes
@@ -526,7 +526,7 @@ mod test {
 
         // Attempt to remove node 0 should fail due to outgoing edges
         let result = graph.remove_node_value(0);
-        assert!(matches!(result, Err(GraphError::NodeHasIncomingEdges(0))));
+        assert!(matches!(result, Err(GraphError::NodeHasOutgoingEdges(0))));
     }
 
     #[test]

--- a/src/edgelist/edge_node_list.rs
+++ b/src/edgelist/edge_node_list.rs
@@ -484,6 +484,9 @@ mod test {
             graph.node_value(1),
             Err(GraphError::NodeNotFound(1))
         ));
+        // Removing again should yield a NodeNotFound error
+        let result = graph.remove_node_value(1);
+        assert!(matches!(result, Err(GraphError::NodeNotFound(1))));
         assert_eq!(graph.iter_nodes().unwrap().count(), 1);
     }
 

--- a/src/edgelist/edge_node_list.rs
+++ b/src/edgelist/edge_node_list.rs
@@ -347,7 +347,7 @@ mod test {
 
     #[test]
     fn test_add_node_to_empty_graph() {
-        let edges = EdgeStructOption([None, None]);
+        let edges: [(usize, usize); 0] = [];
         let nodes = NodeStructOption([None, None, None]); // Capacity for 3 nodes
         let mut graph = EdgeNodeList::new(edges, nodes).unwrap();
 
@@ -408,7 +408,7 @@ mod test {
 
     #[test]
     fn test_add_multiple_nodes() {
-        let edges = EdgeStructOption([None, None]);
+        let edges: [(usize, usize); 0] = [];
         let nodes = NodeStructOption([None, None, None, None, None]); // Capacity for 5 nodes
         let mut graph = EdgeNodeList::new(edges, nodes).unwrap();
 
@@ -434,7 +434,7 @@ mod test {
 
     #[test]
     fn test_add_duplicate_node() {
-        let edges = EdgeStructOption([Some((0usize, 1usize)), None]);
+        let edges = [(0usize, 1usize)];
         let nodes = NodeStructOption([Some(0), Some(1), None]);
         let mut graph = EdgeNodeList::new(edges, nodes).unwrap();
 

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -195,6 +195,31 @@ pub trait GraphWithMutableNodes<NI: NodeIndex>: Graph<NI> {
     fn remove_node(&mut self, node: NI) -> Result<(), Self::Error>;
 }
 
+/// Extension of [`Graph`] that supports adding and removing nodes with values
+///
+/// This trait complements [`GraphWithMutableNodes`] by allowing insertion and
+/// deletion of nodes together with their associated values. Implementations
+/// must uphold the same integrity guarantees as [`GraphWithMutableNodes`],
+/// preventing removal of nodes that still have incoming edges.
+pub trait GraphWithMutableNodeValues<NI, NV>: Graph<NI> + GraphWithNodeValues<NI, NV>
+where
+    NI: NodeIndex,
+{
+    /// Add a new node with a value to the graph
+    ///
+    /// Returns an error if:
+    /// - The node already exists (`DuplicateNode`)
+    /// - The graph is at capacity (`OutOfCapacity`)
+    fn add_node_value(&mut self, node: NI, value: NV) -> Result<(), Self::Error>;
+
+    /// Remove a node and its value from the graph
+    ///
+    /// Returns an error if:
+    /// - The node doesn't exist (`NodeNotFound`)
+    /// - The node still has incoming edges (`NodeHasIncomingEdges`)
+    fn remove_node_value(&mut self, node: NI) -> Result<(), Self::Error>;
+}
+
 /// Extension of [`Graph`] that supports adding and removing edges
 ///
 /// This trait extends basic graph functionality with the ability to dynamically

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -200,7 +200,7 @@ pub trait GraphWithMutableNodes<NI: NodeIndex>: Graph<NI> {
 /// This trait complements [`GraphWithMutableNodes`] by allowing insertion and
 /// deletion of nodes together with their associated values. Implementations
 /// must uphold the same integrity guarantees as [`GraphWithMutableNodes`],
-/// preventing removal of nodes that still have incoming edges.
+/// preventing removal of nodes that still have incoming **or outgoing** edges.
 pub trait GraphWithMutableNodeValues<NI, NV>: Graph<NI> + GraphWithNodeValues<NI, NV>
 where
     NI: NodeIndex,
@@ -216,7 +216,7 @@ where
     ///
     /// Returns an error if:
     /// - The node doesn't exist (`NodeNotFound`)
-    /// - The node still has incoming edges (`NodeHasIncomingEdges`)
+    /// - The node has any incoming or outgoing edges (`NodeHasIncomingEdges`)
     fn remove_node_value(&mut self, node: NI) -> Result<(), Self::Error>;
 }
 

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -38,6 +38,8 @@ pub enum GraphError<NI: NodeIndex> {
     DuplicateNode(NI),
     /// Node cannot be removed because it still has incoming edges
     NodeHasIncomingEdges(NI),
+    /// Node cannot be removed because it still has outgoing edges
+    NodeHasOutgoingEdges(NI),
     /// Unexpected condition occurred
     Unexpected,
 }

--- a/tests/remove_node_value.rs
+++ b/tests/remove_node_value.rs
@@ -1,0 +1,126 @@
+use heapless_graphs::graph::{
+    Graph, GraphError, GraphWithMutableEdges, GraphWithMutableNodeValues,
+};
+
+// A generic test function to verify remove_node_value behavior
+fn test_remove_node_value_with_edges<G, V>(mut graph: G)
+where
+    G: GraphWithMutableNodeValues<usize, V>
+        + GraphWithMutableEdges<usize>
+        + Graph<usize, Error = GraphError<usize>>,
+    V: Default + PartialEq,
+{
+    // Add nodes with default values
+    graph.add_node_value(0, V::default()).unwrap();
+    graph.add_node_value(1, V::default()).unwrap();
+    graph.add_node_value(2, V::default()).unwrap();
+
+    // Add edges
+    graph.add_edge(0, 1).unwrap();
+    graph.add_edge(1, 2).unwrap();
+
+    // 1. Attempt to remove node 0 (has an outgoing edge)
+    let result = graph.remove_node_value(0);
+    assert!(
+        matches!(result, Err(GraphError::NodeHasOutgoingEdges(0))),
+        "Should fail to remove node 0 due to an outgoing edge"
+    );
+    assert!(graph.contains_node(0).unwrap(), "Node 0 should still exist");
+
+    // 2. Attempt to remove node 1 (has both incoming and outgoing edges)
+    let result = graph.remove_node_value(1);
+    assert!(
+        matches!(result, Err(GraphError::NodeHasIncomingEdges(1))),
+        "Should fail to remove node 1 due to an incoming edge"
+    );
+    assert!(graph.contains_node(1).unwrap(), "Node 1 should still exist");
+
+    // 3. Remove the edge 0->1, making node 1 only have an outgoing edge
+    graph.remove_edge(0, 1).unwrap();
+
+    // 4. Attempt to remove node 1 again (still has an outgoing edge)
+    let result = graph.remove_node_value(1);
+    assert!(
+        matches!(result, Err(GraphError::NodeHasOutgoingEdges(1))),
+        "Should fail to remove node 1 due to an outgoing edge after removing the incoming one"
+    );
+    assert!(graph.contains_node(1).unwrap(), "Node 1 should still exist");
+
+    // 5. Remove the edge 1->2, isolating node 1
+    graph.remove_edge(1, 2).unwrap();
+
+    // 6. Now, removing node 1 should succeed
+    let result = graph.remove_node_value(1);
+    assert!(result.is_ok(), "Should succeed in removing isolated node 1");
+    assert!(!graph.contains_node(1).unwrap(), "Node 1 should be gone");
+}
+
+// A generic test function to verify remove_node_value for isolated nodes
+fn test_remove_isolated_node_value<G, V>(mut graph: G)
+where
+    G: GraphWithMutableNodeValues<usize, V> + Graph<usize, Error = GraphError<usize>>,
+    V: Default + PartialEq,
+{
+    // Add nodes with default values
+    graph.add_node_value(0, V::default()).unwrap();
+    graph.add_node_value(1, V::default()).unwrap();
+    graph.add_node_value(2, V::default()).unwrap();
+
+    // Remove an isolated node
+    let result = graph.remove_node_value(1);
+    assert!(result.is_ok(), "Should succeed in removing isolated node 1");
+    assert!(!graph.contains_node(1).unwrap(), "Node 1 should be gone");
+
+    // Verify other nodes are unaffected
+    assert!(graph.contains_node(0).unwrap(), "Node 0 should still exist");
+    assert!(graph.contains_node(2).unwrap(), "Node 2 should still exist");
+}
+
+// A generic test function to verify remove_node_value for non-existent nodes
+fn test_remove_nonexistent_node_value<G, V>(mut graph: G)
+where
+    G: GraphWithMutableNodeValues<usize, V> + Graph<usize, Error = GraphError<usize>>,
+    V: Default,
+{
+    // Add some nodes
+    graph.add_node_value(0, V::default()).unwrap();
+    graph.add_node_value(2, V::default()).unwrap();
+
+    // Attempt to remove a node that doesn't exist
+    let result = graph.remove_node_value(1);
+    assert!(
+        matches!(result, Err(GraphError::NodeNotFound(1))),
+        "Should fail to remove non-existent node 1"
+    );
+
+    // Verify the graph is unchanged
+    assert_eq!(graph.iter_nodes().unwrap().count(), 2);
+}
+
+use heapless_graphs::edgelist::edge_node_list::EdgeNodeList;
+use heapless_graphs::edges::EdgeStructOption;
+use heapless_graphs::nodes::NodeValueStructOption;
+
+#[test]
+fn remove_node_value_with_edges_edgenodelist() {
+    let edges = EdgeStructOption([None; 10]);
+    let nodes = NodeValueStructOption([None; 10]);
+    let graph = EdgeNodeList::new(edges, nodes).unwrap();
+    test_remove_node_value_with_edges::<_, i32>(graph);
+}
+
+#[test]
+fn remove_isolated_node_value_edgenodelist() {
+    let edges = EdgeStructOption([None; 10]);
+    let nodes = NodeValueStructOption([None; 10]);
+    let graph = EdgeNodeList::new(edges, nodes).unwrap();
+    test_remove_isolated_node_value::<_, i32>(graph);
+}
+
+#[test]
+fn remove_nonexistent_node_value_edgenodelist() {
+    let edges = EdgeStructOption([None; 10]);
+    let nodes = NodeValueStructOption([None; 10]);
+    let graph = EdgeNodeList::new(edges, nodes).unwrap();
+    test_remove_nonexistent_node_value::<_, i32>(graph);
+}


### PR DESCRIPTION
## Summary
- add `GraphWithMutableNodeValues` trait for adding/removing node-value pairs
- implement the trait for `EdgeNodeList`
- extend unit tests to cover node-value insertion and removal
- document the new trait in README and DESIGN
- mark todo item as complete

## Testing
- `cargo test`
- `cargo test --no-default-features`
- `cargo test --no-default-features --features heapless`
- `cargo test --no-default-features --features std`
- `cargo test --no-default-features --features heapless,std`

------
https://chatgpt.com/codex/tasks/task_e_687fa4f6eed88331948a9f79170c7f85

## Summary by Sourcery

Introduce a new GraphWithMutableNodeValues trait for adding and removing nodes with associated values, implement it for EdgeNodeList, and update documentation and tests accordingly

New Features:
- Add GraphWithMutableNodeValues trait to enable dynamic insertion and removal of nodes with values
- Implement the GraphWithMutableNodeValues trait for the EdgeNodeList graph structure

Documentation:
- Document the new GraphWithMutableNodeValues trait in README and DESIGN.md
- Mark the corresponding TODO item as complete in TODO.md

Tests:
- Add unit tests covering successful node-value additions and removals as well as error conditions (duplicate nodes, capacity limits, incoming edges)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for adding and removing nodes with associated values, including integrity checks to prevent removal if nodes have incoming or outgoing edges.

* **Documentation**
  * Updated documentation to describe the new graph-level trait for managing nodes with values and clarified current implementation support.
  * Marked the relevant TODO checklist item as complete.

* **Tests**
  * Introduced comprehensive tests to verify correct behavior when adding and removing nodes with values, including edge cases and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->