### PR TITLE
Fix remove node

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ description = """
 Implementation of composable graphs for no_alloc environments
 """
 keywords = ["graph", "static", "no-heap"]
-categories = [ "data-structures", "no-std" ]
+categories = [ "data-structures", "no-std", "no-std::no-alloc"]
 readme = "README.md"
 license = "Apache-2.0"
 exclude = ["/.github/*"]

--- a/src/adjacency_list/map_adjacency_list.rs
+++ b/src/adjacency_list/map_adjacency_list.rs
@@ -131,6 +131,11 @@ where
             return Err(GraphError::NodeHasIncomingEdges(node));
         }
 
+        // Check if node has outgoing edges
+        if self.outgoing_edges(node)?.next().is_some() {
+            return Err(GraphError::NodeHasOutgoingEdges(node));
+        }
+
         // Remove the node (this automatically removes all its outgoing edges)
         self.nodes.remove(&node);
         Ok(())

--- a/src/edgelist/edge_node_list.rs
+++ b/src/edgelist/edge_node_list.rs
@@ -162,6 +162,11 @@ where
             return Err(GraphError::NodeHasIncomingEdges(node));
         }
 
+        // Check if node has outgoing edges
+        if self.outgoing_edges(node)?.next().is_some() {
+            return Err(GraphError::NodeHasOutgoingEdges(node));
+        }
+
         // Remove the node from the nodes container
         self.nodes
             .remove(node)

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -191,9 +191,8 @@ pub trait GraphWithMutableNodes<NI: NodeIndex>: Graph<NI> {
     ///
     /// Returns an error if:
     /// - The node doesn't exist (`NodeNotFound`)
-    /// - The node still has incoming edges (`NodeHasIncomingEdges`)
-    ///
-    /// Note: Outgoing edges from the node are automatically removed.
+    /// - The node has any incoming edges (`NodeHasIncomingEdges`)
+    /// - The node has any outgoing edges (`NodeHasOutgoingEdges`)
     fn remove_node(&mut self, node: NI) -> Result<(), Self::Error>;
 }
 

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -38,6 +38,8 @@ pub enum GraphError<NI: NodeIndex> {
     DuplicateNode(NI),
     /// Node cannot be removed because it still has incoming edges
     NodeHasIncomingEdges(NI),
+    /// Node cannot be removed because it still has outgoing edges
+    NodeHasOutgoingEdges(NI),
     /// Unexpected condition occurred
     Unexpected,
 }

--- a/src/matrix/bit_map_matrix.rs
+++ b/src/matrix/bit_map_matrix.rs
@@ -250,6 +250,11 @@ where
             return Err(GraphError::NodeHasIncomingEdges(node));
         }
 
+        // Check if node has outgoing edges
+        if self.outgoing_edges(node)?.next().is_some() {
+            return Err(GraphError::NodeHasOutgoingEdges(node));
+        }
+
         // Remove the node mapping (bit matrix position becomes available for reuse)
         self.index_map.remove(&node);
         Ok(())

--- a/src/matrix/map_matrix.rs
+++ b/src/matrix/map_matrix.rs
@@ -279,6 +279,11 @@ where
             return Err(GraphError::NodeHasIncomingEdges(node));
         }
 
+        // Check if node has outgoing edges
+        if self.outgoing_edges(node)?.next().is_some() {
+            return Err(GraphError::NodeHasOutgoingEdges(node));
+        }
+
         // Remove the node mapping (matrix position becomes available for reuse)
         self.index_map.remove(&node);
         Ok(())

--- a/tests/remove_node.rs
+++ b/tests/remove_node.rs
@@ -1,0 +1,97 @@
+use heapless_graphs::adjacency_list::map_adjacency_list::MapAdjacencyList;
+use heapless_graphs::containers::maps::staticdict::Dictionary;
+use heapless_graphs::containers::maps::MapTrait;
+use heapless_graphs::edgelist::edge_node_list::EdgeNodeList;
+use heapless_graphs::edges::EdgeStructOption;
+use heapless_graphs::graph::{Graph, GraphError, GraphWithMutableEdges, GraphWithMutableNodes};
+use heapless_graphs::matrix::bit_map_matrix::BitMapMatrix;
+use heapless_graphs::matrix::bit_matrix::BitMatrix;
+use heapless_graphs::matrix::map_matrix::MapMatrix;
+use heapless_graphs::nodes::NodeStructOption;
+
+// A generic test function to verify remove_node behavior
+fn test_remove_node_with_outgoing_edges<G>(mut graph: G)
+where
+    G: GraphWithMutableNodes<usize>
+        + GraphWithMutableEdges<usize>
+        + Graph<usize, Error = GraphError<usize>>,
+{
+    // Add nodes 0, 1, 2
+    graph.add_node(0).unwrap();
+    graph.add_node(1).unwrap();
+    graph.add_node(2).unwrap();
+
+    // Add edges 0->1 and 1->2
+    graph.add_edge(0, 1).unwrap();
+    graph.add_edge(1, 2).unwrap();
+
+    // 1. Attempt to remove node 0 (has outgoing edge to 1)
+    let result = graph.remove_node(0);
+    assert!(
+        matches!(result, Err(GraphError::NodeHasOutgoingEdges(0))),
+        "Should fail removing node 0 due to outgoing edge"
+    );
+    assert!(graph.contains_node(0).unwrap(), "Node 0 should still exist");
+
+    // 2. Attempt to remove node 1 (has incoming from 0 and outgoing to 2)
+    let result = graph.remove_node(1);
+    assert!(
+        matches!(result, Err(GraphError::NodeHasIncomingEdges(1))),
+        "Should fail removing node 1 due to incoming edge"
+    );
+    assert!(graph.contains_node(1).unwrap(), "Node 1 should still exist");
+
+    // 3. Remove the edge 0->1
+    graph.remove_edge(0, 1).unwrap();
+
+    // 4. Now, removing node 0 should succeed as it has no more outgoing edges
+    let result = graph.remove_node(0);
+    assert!(result.is_ok(), "Should succeed removing node 0 now");
+    assert!(!graph.contains_node(0).unwrap(), "Node 0 should be gone");
+
+    // 5. Attempt to remove node 1 again (still has outgoing edge to 2)
+    let result = graph.remove_node(1);
+    assert!(
+        matches!(result, Err(GraphError::NodeHasOutgoingEdges(1))),
+        "Should fail removing node 1 due to outgoing edge to 2"
+    );
+
+    // 6. Remove edge 1->2
+    graph.remove_edge(1, 2).unwrap();
+
+    // 7. Now removing node 1 should succeed
+    let result = graph.remove_node(1);
+    assert!(result.is_ok(), "Should succeed removing node 1 now");
+    assert!(!graph.contains_node(1).unwrap(), "Node 1 should be gone");
+}
+
+#[test]
+fn remove_node_map_adjacency_list() {
+    let dict = Dictionary::<usize, NodeStructOption<5, usize>, 10>::new();
+    let graph = MapAdjacencyList::new(dict).unwrap();
+    test_remove_node_with_outgoing_edges(graph);
+}
+
+#[test]
+fn remove_node_edge_node_list() {
+    let edges = EdgeStructOption([None; 10]);
+    let nodes = NodeStructOption([None; 10]);
+    let graph = EdgeNodeList::new(edges, nodes).unwrap();
+    test_remove_node_with_outgoing_edges(graph);
+}
+
+#[test]
+fn remove_node_bit_map_matrix() {
+    let bitmap = BitMatrix::<1, 8>::new_unchecked([[0; 1]; 8]);
+    let index_map = Dictionary::<usize, usize, 10>::new();
+    let graph = BitMapMatrix::new(bitmap, index_map).unwrap();
+    test_remove_node_with_outgoing_edges(graph);
+}
+
+#[test]
+fn remove_node_map_matrix() {
+    let matrix = [[None; 10]; 10];
+    let index_map = Dictionary::<usize, usize, 10>::new();
+    let graph = MapMatrix::<10, usize, (), _, _, _>::new(matrix, index_map).unwrap();
+    test_remove_node_with_outgoing_edges(graph);
+}

--- a/tests/remove_node.rs
+++ b/tests/remove_node.rs
@@ -65,11 +65,115 @@ where
     assert!(!graph.contains_node(1).unwrap(), "Node 1 should be gone");
 }
 
+// A generic test function to verify remove_node behavior for isolated nodes
+fn test_remove_isolated_node<G>(mut graph: G)
+where
+    G: GraphWithMutableNodes<usize> + Graph<usize, Error = GraphError<usize>>,
+{
+    // Add nodes 0, 1, 2
+    graph.add_node(0).unwrap();
+    graph.add_node(1).unwrap();
+    graph.add_node(2).unwrap();
+
+    // Remove node 1, which is isolated
+    let result = graph.remove_node(1);
+    assert!(result.is_ok(), "Should succeed removing isolated node 1");
+    assert!(!graph.contains_node(1).unwrap(), "Node 1 should be gone");
+
+    // Verify other nodes are unaffected
+    assert!(graph.contains_node(0).unwrap(), "Node 0 should still exist");
+    assert!(graph.contains_node(2).unwrap(), "Node 2 should still exist");
+}
+
 #[test]
 fn remove_node_map_adjacency_list() {
     let dict = Dictionary::<usize, NodeStructOption<5, usize>, 10>::new();
     let graph = MapAdjacencyList::new(dict).unwrap();
     test_remove_node_with_outgoing_edges(graph);
+}
+
+#[test]
+fn remove_isolated_node_map_adjacency_list() {
+    let dict = Dictionary::<usize, NodeStructOption<5, usize>, 10>::new();
+    let graph = MapAdjacencyList::new(dict).unwrap();
+    test_remove_isolated_node(graph);
+}
+
+#[test]
+fn remove_isolated_node_edge_node_list() {
+    let edges = EdgeStructOption([None; 10]);
+    let nodes = NodeStructOption([None; 10]);
+    let graph = EdgeNodeList::new(edges, nodes).unwrap();
+    test_remove_isolated_node(graph);
+}
+
+#[test]
+fn remove_isolated_node_bit_map_matrix() {
+    let bitmap = BitMatrix::<1, 8>::new_unchecked([[0; 1]; 8]);
+    let index_map = Dictionary::<usize, usize, 10>::new();
+    let graph = BitMapMatrix::new(bitmap, index_map).unwrap();
+    test_remove_isolated_node(graph);
+}
+
+#[test]
+fn remove_isolated_node_map_matrix() {
+    let matrix = [[None; 10]; 10];
+    let index_map = Dictionary::<usize, usize, 10>::new();
+    let graph = MapMatrix::<10, usize, (), _, _, _>::new(matrix, index_map).unwrap();
+    test_remove_isolated_node(graph);
+}
+
+// A generic test function to verify remove_node behavior for nonexistent nodes
+fn test_remove_nonexistent_node<G>(mut graph: G)
+where
+    G: GraphWithMutableNodes<usize> + Graph<usize, Error = GraphError<usize>>,
+{
+    // Add some nodes
+    graph.add_node(0).unwrap();
+    graph.add_node(2).unwrap();
+
+    // Attempt to remove a node that doesn't exist
+    let result = graph.remove_node(1);
+    assert!(
+        matches!(result, Err(GraphError::NodeNotFound(1))),
+        "Should fail removing nonexistent node 1"
+    );
+
+    // Verify other nodes are unaffected
+    assert!(graph.contains_node(0).unwrap(), "Node 0 should still exist");
+    assert!(graph.contains_node(2).unwrap(), "Node 2 should still exist");
+    assert_eq!(graph.iter_nodes().unwrap().count(), 2);
+}
+
+#[test]
+fn remove_nonexistent_node_map_adjacency_list() {
+    let dict = Dictionary::<usize, NodeStructOption<5, usize>, 10>::new();
+    let graph = MapAdjacencyList::new(dict).unwrap();
+    test_remove_nonexistent_node(graph);
+}
+
+#[test]
+fn remove_nonexistent_node_edge_node_list() {
+    let edges = EdgeStructOption([None; 10]);
+    let nodes = NodeStructOption([None; 10]);
+    let graph = EdgeNodeList::new(edges, nodes).unwrap();
+    test_remove_nonexistent_node(graph);
+}
+
+#[test]
+fn remove_nonexistent_node_bit_map_matrix() {
+    let bitmap = BitMatrix::<1, 8>::new_unchecked([[0; 1]; 8]);
+    let index_map = Dictionary::<usize, usize, 10>::new();
+    let graph = BitMapMatrix::new(bitmap, index_map).unwrap();
+    test_remove_nonexistent_node(graph);
+}
+
+#[test]
+fn remove_nonexistent_node_map_matrix() {
+    let matrix = [[None; 10]; 10];
+    let index_map = Dictionary::<usize, usize, 10>::new();
+    let graph = MapMatrix::<10, usize, (), _, _, _>::new(matrix, index_map).unwrap();
+    test_remove_nonexistent_node(graph);
 }
 
 #[test]


### PR DESCRIPTION
## Summary by Sourcery

Enforce outgoing-edge constraints when removing nodes by adding a new error variant and checks across all graph implementations, update crate metadata, and add tests to validate remove_node behavior.

Bug Fixes:
- Prevent removal of nodes that still have outgoing edges by checking outgoing_edges and returning NodeHasOutgoingEdges.

Tests:
- Add generic tests to verify remove_node errors for nodes with incoming or outgoing edges and successful removal once edges are cleared across all graph types.

Chores:
- Update Cargo.toml categories to include "no-std::no-alloc".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved error handling when removing nodes by introducing a specific error for nodes with outgoing edges.
  * Enhanced node removal validation to prevent removal of nodes that have any incoming or outgoing edges across all graph implementations.

* **Tests**
  * Added comprehensive tests to ensure correct behavior when attempting to remove nodes with incoming or outgoing edges in various graph types.

* **Chores**
  * Updated crate metadata with an additional category tag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->